### PR TITLE
fix(#8): apply backdrop color for any input node, not just Read

### DIFF
--- a/anchor.py
+++ b/anchor.py
@@ -72,8 +72,7 @@ def find_anchor_color(anchor):
     """Return the tile color an anchor should display.
 
     Priority:
-      1. Smallest BackdropNode containing the anchor — only when the effective
-         input (first non-Dot ancestor) is a Read node.
+      1. Smallest BackdropNode containing the anchor (any input node type).
       2. The effective input node color (with Preferences fallback).
       3. Hard-coded default purple if neither is available.
 
@@ -92,8 +91,8 @@ def find_anchor_color(anchor):
     else:
         effective_input = direct_input
 
-    # --- 1. Backdrop color — only for Read nodes ---
-    if effective_input is not None and effective_input.Class() == 'Read':
+    # --- 1. Backdrop color (any input node type) ---
+    if effective_input is not None:
         smallest = find_smallest_containing_backdrop(anchor)
         if smallest is not None:
             color = smallest['tile_color'].value()
@@ -429,7 +428,7 @@ def create_anchor():
     # find_anchor_color() here because that function expects the anchor to already
     # exist and calls anchor.input(0) — passing input_node would instead examine
     # what is upstream *of* input_node.  Mirror the same priority logic directly:
-    #   1. Backdrop colour — only when effective input is a Read
+    #   1. Backdrop colour (any input node type)
     #   2. Effective input node's own colour (tile_color with Preferences fallback)
     #   3. Hard-coded default purple
     #
@@ -445,12 +444,9 @@ def create_anchor():
         else:
             color_source_node = input_node
 
-        if color_source_node.Class() == 'Read':
-            containing_backdrop = find_smallest_containing_backdrop(color_source_node)
-            if containing_backdrop is not None and containing_backdrop['tile_color'].value() != 0:
-                pre_color = int(containing_backdrop['tile_color'].value())
-            else:
-                pre_color = int(find_node_color(color_source_node))
+        containing_backdrop = find_smallest_containing_backdrop(color_source_node)
+        if containing_backdrop is not None and containing_backdrop['tile_color'].value() != 0:
+            pre_color = int(containing_backdrop['tile_color'].value())
         else:
             pre_color = int(find_node_color(color_source_node))
     else:

--- a/tests/test_dot_name_suggestion.py
+++ b/tests/test_dot_name_suggestion.py
@@ -7,6 +7,7 @@ selected input node is a Dot:
   TestUnlabelledDotNameSuggestion   — unlabelled Dot delegates to first non-Dot ancestor
   TestDotChainNameSuggestion        — chains of Dots (Dot→Dot→Read) are fully traversed
   TestFindAnchorColorDot            — find_anchor_color() resolves through unlabelled Dots
+  TestFindAnchorColorBackdrop       — find_anchor_color() uses backdrop color for any node type (issue #8)
 """
 
 import sys
@@ -287,6 +288,88 @@ class TestFindAnchorColorDot(unittest.TestCase):
             result = anchor.find_anchor_color(anchor_node)
 
         self.assertEqual(result, ANCHOR_DEFAULT_COLOR)
+
+
+class TestFindAnchorColorBackdrop(unittest.TestCase):
+    """find_anchor_color() uses backdrop color for any input node type (issue #8 regression)."""
+
+    def _make_backdrop(self, color):
+        return StubNode(
+            name='BackdropNode1',
+            node_class='BackdropNode',
+            knobs_dict={'tile_color': StubKnob(color)},
+        )
+
+    def _make_anchor(self, input_node):
+        anchor_node = StubNode(
+            name='Anchor_test',
+            node_class='NoOp',
+            knobs_dict={'tile_color': StubKnob(0)},
+        )
+        anchor_node.setInput(0, input_node)
+        return anchor_node
+
+    def test_non_read_input_inside_backdrop_returns_backdrop_color(self):
+        """Anchor with a non-Read input inside a backdrop must return the backdrop color.
+
+        Regression for issue #8: backdrop color was only applied when input was a Read node.
+        """
+        backdrop_color = 0x336699FF
+        backdrop = self._make_backdrop(backdrop_color)
+
+        noop_input = StubNode(name='Grade1', node_class='Grade', knobs_dict={})
+        noop_node_color = 0xAABBCCFF
+
+        anchor_node = self._make_anchor(noop_input)
+
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop), \
+             patch('anchor.find_node_color', return_value=noop_node_color):
+            result = anchor.find_anchor_color(anchor_node)
+
+        self.assertEqual(result, backdrop_color,
+                         "Backdrop color must be used for non-Read inputs (was broken in issue #8)")
+
+    def test_read_input_inside_backdrop_still_returns_backdrop_color(self):
+        """Anchor with a Read input inside a backdrop must still return the backdrop color."""
+        backdrop_color = 0xFF6600FF
+        backdrop = self._make_backdrop(backdrop_color)
+
+        read_node = _make_read('plate_v001.exr')
+        read_color = 0x112233FF
+        anchor_node = self._make_anchor(read_node)
+
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop), \
+             patch('anchor.find_node_color', return_value=read_color):
+            result = anchor.find_anchor_color(anchor_node)
+
+        self.assertEqual(result, backdrop_color)
+
+    def test_non_read_input_outside_backdrop_returns_node_color(self):
+        """Anchor with a non-Read input and no containing backdrop uses the node's color."""
+        noop_input = StubNode(name='Grade1', node_class='Grade', knobs_dict={})
+        node_color = 0xAABBCCFF
+        anchor_node = self._make_anchor(noop_input)
+
+        with patch('anchor.find_smallest_containing_backdrop', return_value=None), \
+             patch('anchor.find_node_color', return_value=node_color) as mock_find_color:
+            result = anchor.find_anchor_color(anchor_node)
+
+        mock_find_color.assert_called_once_with(noop_input)
+        self.assertEqual(result, node_color)
+
+    def test_zero_backdrop_color_falls_through_to_node_color(self):
+        """Backdrop with tile_color == 0 (unset) must not suppress the node color."""
+        backdrop = self._make_backdrop(0)
+
+        noop_input = StubNode(name='Grade1', node_class='Grade', knobs_dict={})
+        node_color = 0xDEADBEEF
+        anchor_node = self._make_anchor(noop_input)
+
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop), \
+             patch('anchor.find_node_color', return_value=node_color):
+            result = anchor.find_anchor_color(anchor_node)
+
+        self.assertEqual(result, node_color)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Removes the `input.Class() == 'Read'` guard in `find_anchor_color()` so backdrop color is used for any input node type, not only Read nodes
- Applies the same fix to the mirrored pre-color derivation in `create_anchor()` (used to pre-seed the color picker dialog)
- Adds `TestFindAnchorColorBackdrop` with 4 regression tests covering the fixed behaviour

## Test plan

- [ ] All 254 existing tests pass
- [ ] New `TestFindAnchorColorBackdrop.test_non_read_input_inside_backdrop_returns_backdrop_color` confirms the regression case is fixed
- [x] Anchor created with a non-Read input (e.g. Grade, Merge) inside a coloured backdrop picks up the backdrop colour

Closes #8