### PR TITLE
fix(#10): strip HTML tags from backdrop/Dot labels when suggesting anchor names

### DIFF
--- a/anchor.py
+++ b/anchor.py
@@ -50,6 +50,15 @@ def sanitize_anchor_name(name):
     return re.sub(r'[^A-Za-z0-9_]', '_', name.strip())
 
 
+def _strip_html_tags(text):
+    """Remove HTML tags from *text*, handling both closed and unclosed tags.
+
+    Nuke allows unclosed tags in node labels (e.g. ``<b>PLATES``), so this
+    uses a simple regex rather than an HTML parser.
+    """
+    return re.sub(r'<[^>]*>', '', text)
+
+
 def _find_first_non_dot_input(node):
     """Traverse input(0) upward through Dot nodes and return the first non-Dot node.
 
@@ -234,12 +243,12 @@ def suggest_anchor_name(input_node):
 
     # --- Dot node: label or upstream delegation ---
     if input_node.Class() == 'Dot':
-        dot_label = input_node['label'].getValue().strip() if 'label' in input_node.knobs() else ''
+        dot_label = _strip_html_tags(input_node['label'].getValue().strip()) if 'label' in input_node.knobs() else ''
         if dot_label:
             # Labelled Dot: suggest the label, prefixed by containing backdrop if present.
             smallest = find_smallest_containing_backdrop(input_node)
             if smallest is not None:
-                backdrop_label = smallest['label'].getValue().strip()
+                backdrop_label = _strip_html_tags(smallest['label'].getValue().strip())
                 if backdrop_label:
                     return backdrop_label + '_' + dot_label
             return dot_label
@@ -281,7 +290,7 @@ def suggest_anchor_name(input_node):
 
     smallest = find_smallest_containing_backdrop(input_node)
     if smallest is not None:
-        label = smallest['label'].getValue().strip()
+        label = _strip_html_tags(smallest['label'].getValue().strip())
         if label:
             suggestion = label + '_' + suggestion
 

--- a/tests/test_anchor_naming.py
+++ b/tests/test_anchor_naming.py
@@ -270,5 +270,93 @@ class TestRegexNoMatchFallback(unittest.TestCase):
         self.assertEqual(result, 'plate')
 
 
+class TestHtmlStrippingInBackdropLabel(unittest.TestCase):
+    """HTML tags in backdrop labels are stripped before use as a name prefix.
+
+    Regression tests for issue #10.
+    """
+
+    def setUp(self):
+        self._original_naming_regex = getattr(prefs_module, 'naming_regex', '')
+        self._original_naming_template = getattr(prefs_module, 'naming_template', '')
+        prefs_module.naming_regex = ''
+        prefs_module.naming_template = ''
+
+    def tearDown(self):
+        prefs_module.naming_regex = self._original_naming_regex
+        prefs_module.naming_template = self._original_naming_template
+
+    def _make_backdrop(self, label):
+        label_knob = StubKnob(value=label, knob_name='label')
+        return StubNode(name='BackdropNode1', node_class='BackdropNode', knobs_dict={'label': label_knob})
+
+    def test_fully_wrapped_html_tags_stripped_from_backdrop_label(self):
+        """<center><b><i>PLATES</i></b></center> in backdrop label becomes PLATES prefix."""
+        node = _make_read_node('shot_v001.exr')
+        backdrop = self._make_backdrop('<center><b><i>PLATES</i></b></center>')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop):
+            result = anchor.suggest_anchor_name(node)
+        self.assertEqual(result, 'PLATES_shot')
+
+    def test_unclosed_html_tag_stripped_from_backdrop_label(self):
+        """<b>PLATES (unclosed tag, valid in Nuke) in backdrop label becomes PLATES prefix."""
+        node = _make_read_node('shot_v001.exr')
+        backdrop = self._make_backdrop('<b>PLATES')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop):
+            result = anchor.suggest_anchor_name(node)
+        self.assertEqual(result, 'PLATES_shot')
+
+    def test_mixed_html_and_plain_text_stripped(self):
+        """Tags interspersed with text are all removed, leaving only plain text."""
+        node = _make_read_node('shot_v001.exr')
+        backdrop = self._make_backdrop('<b>COMP<i>_WORK</i>')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop):
+            result = anchor.suggest_anchor_name(node)
+        self.assertEqual(result, 'COMP_WORK_shot')
+
+    def test_plain_backdrop_label_unchanged(self):
+        """Backdrop labels with no HTML pass through unchanged."""
+        node = _make_read_node('shot_v001.exr')
+        backdrop = self._make_backdrop('PLATES')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop):
+            result = anchor.suggest_anchor_name(node)
+        self.assertEqual(result, 'PLATES_shot')
+
+
+class TestHtmlStrippingInDotLabel(unittest.TestCase):
+    """HTML tags in Dot node labels are stripped before use as a name suggestion.
+
+    Regression tests for issue #10.
+    """
+
+    def setUp(self):
+        self._original_naming_regex = getattr(prefs_module, 'naming_regex', '')
+        self._original_naming_template = getattr(prefs_module, 'naming_template', '')
+        prefs_module.naming_regex = ''
+        prefs_module.naming_template = ''
+
+    def tearDown(self):
+        prefs_module.naming_regex = self._original_naming_regex
+        prefs_module.naming_template = self._original_naming_template
+
+    def _make_labelled_dot(self, label):
+        label_knob = StubKnob(value=label, knob_name='label')
+        return StubNode(name='Dot1', node_class='Dot', knobs_dict={'label': label_knob})
+
+    def test_html_tags_stripped_from_dot_label(self):
+        """<b>PLATES</b> in a Dot label becomes PLATES."""
+        dot = self._make_labelled_dot('<b>PLATES</b>')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=None):
+            result = anchor.suggest_anchor_name(dot)
+        self.assertEqual(result, 'PLATES')
+
+    def test_unclosed_html_tag_stripped_from_dot_label(self):
+        """<b>PLATES (unclosed) in a Dot label becomes PLATES."""
+        dot = self._make_labelled_dot('<b>PLATES')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=None):
+            result = anchor.suggest_anchor_name(dot)
+        self.assertEqual(result, 'PLATES')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `_strip_html_tags()` helper in `anchor.py` using a simple regex (`<[^>]*>`) that handles both closed and unclosed tags (Nuke allows `<b>PLATES` without a closing tag)
- Applies stripping to backdrop labels and Dot node labels in `suggest_anchor_name()` — both the Dot path and the general node path
- Adds 6 regression tests covering: fully wrapped tags, unclosed tags, mixed inline tags, plain labels, and Dot node labels

Closes #10

## Test plan

- [x] `tests/test_anchor_naming.py` — 19 tests all pass (6 new regression tests added)
- [x] Full suite — 260/260 passing