### PR TITLE
fix(#11): shift anchor color for contrast against containing backdrop

### DIFF
--- a/anchor.py
+++ b/anchor.py
@@ -50,6 +50,15 @@ def sanitize_anchor_name(name):
     return re.sub(r'[^A-Za-z0-9_]', '_', name.strip())
 
 
+def _strip_html_tags(text):
+    """Remove HTML tags from *text*, handling both closed and unclosed tags.
+
+    Nuke allows unclosed tags in node labels (e.g. ``<b>PLATES``), so this
+    uses a simple regex rather than an HTML parser.
+    """
+    return re.sub(r'<[^>]*>', '', text)
+
+
 def _find_first_non_dot_input(node):
     """Traverse input(0) upward through Dot nodes and return the first non-Dot node.
 
@@ -234,12 +243,12 @@ def suggest_anchor_name(input_node):
 
     # --- Dot node: label or upstream delegation ---
     if input_node.Class() == 'Dot':
-        dot_label = input_node['label'].getValue().strip() if 'label' in input_node.knobs() else ''
+        dot_label = _strip_html_tags(input_node['label'].getValue().strip()) if 'label' in input_node.knobs() else ''
         if dot_label:
             # Labelled Dot: suggest the label, prefixed by containing backdrop if present.
             smallest = find_smallest_containing_backdrop(input_node)
             if smallest is not None:
-                backdrop_label = smallest['label'].getValue().strip()
+                backdrop_label = _strip_html_tags(smallest['label'].getValue().strip())
                 if backdrop_label:
                     return backdrop_label + '_' + dot_label
             return dot_label
@@ -281,7 +290,7 @@ def suggest_anchor_name(input_node):
 
     smallest = find_smallest_containing_backdrop(input_node)
     if smallest is not None:
-        label = smallest['label'].getValue().strip()
+        label = _strip_html_tags(smallest['label'].getValue().strip())
         if label:
             suggestion = label + '_' + suggestion
 

--- a/anchor.py
+++ b/anchor.py
@@ -21,7 +21,7 @@ except ImportError:
 
 import prefs
 import tabtabtab_anchors as _tabtabtab
-from colors import ColorPaletteDialog
+from colors import ColorPaletteDialog, adjust_color_for_backdrop_contrast
 from constants import (
     ANCHOR_DEFAULT_COLOR,
     ANCHOR_PREFIX,
@@ -106,7 +106,7 @@ def find_anchor_color(anchor):
         if smallest is not None:
             color = smallest['tile_color'].value()
             if color != 0:
-                return color
+                return adjust_color_for_backdrop_contrast(color)
 
     # --- 2. Effective input node color (with Preferences fallback) ---
     if effective_input is not None:
@@ -455,7 +455,7 @@ def create_anchor():
 
         containing_backdrop = find_smallest_containing_backdrop(color_source_node)
         if containing_backdrop is not None and containing_backdrop['tile_color'].value() != 0:
-            pre_color = int(containing_backdrop['tile_color'].value())
+            pre_color = adjust_color_for_backdrop_contrast(int(containing_backdrop['tile_color'].value()))
         else:
             pre_color = int(find_node_color(color_source_node))
     else:

--- a/colors.py
+++ b/colors.py
@@ -38,18 +38,25 @@ def _get_nuke_pref_colors():
 
 
 def _get_script_backdrop_colors():
-    """Return list of unique backdrop tile_color ints from the current script.
+    """Return list of unique contrast-adjusted backdrop colors from the current script.
+
+    Each raw backdrop tile_color is passed through adjust_color_for_backdrop_contrast()
+    so that the swatches shown in the palette represent the actual color that will be
+    assigned to an anchor placed inside that backdrop — not the backdrop color itself.
 
     Returns an empty list when called outside a Nuke session.
     """
     seen = set()
-    colors = []
+    adjusted_colors = []
     for backdrop_node in nuke.allNodes('BackdropNode'):
-        color = int(backdrop_node['tile_color'].value())
-        if color and color not in seen:
-            seen.add(color)
-            colors.append(color)
-    return colors
+        raw_color = int(backdrop_node['tile_color'].value())
+        if not raw_color:
+            continue
+        adjusted_color = adjust_color_for_backdrop_contrast(raw_color)
+        if adjusted_color not in seen:
+            seen.add(adjusted_color)
+            adjusted_colors.append(adjusted_color)
+    return adjusted_colors
 
 
 # ---------------------------------------------------------------------------
@@ -62,6 +69,63 @@ def _color_int_to_rgb(color_int):
     green = (color_int >> 16) & 0xFF
     blue = (color_int >> 8) & 0xFF
     return red, green, blue
+
+
+def adjust_color_for_backdrop_contrast(backdrop_color_int):
+    """Return an anchor color that contrasts with the given backdrop color.
+
+    Backdrops and anchors default to the same color, making anchors invisible.
+    This function shifts the anchor's lightness (and saturation slightly) so it
+    reads distinctly against its backdrop while remaining clearly related to it.
+
+    The transform is deterministic: bright backdrops (L > 0.5) produce a darker,
+    more-saturated anchor; dark backdrops produce a brighter, less-saturated one.
+    The alpha byte is preserved unchanged.
+
+    Parameters
+    ----------
+    backdrop_color_int : int
+        Backdrop tile_color in 0xRRGGBBAA format.
+
+    Returns
+    -------
+    int
+        Adjusted anchor color in 0xRRGGBBAA format.
+    """
+    import colorsys
+
+    _LIGHTNESS_SHIFT = 0.22
+    _SATURATION_SHIFT = 0.15
+
+    red, green, blue = _color_int_to_rgb(backdrop_color_int)
+    alpha = backdrop_color_int & 0xFF
+
+    red_normalized = red / 255.0
+    green_normalized = green / 255.0
+    blue_normalized = blue / 255.0
+
+    hue, lightness, saturation = colorsys.rgb_to_hls(
+        red_normalized, green_normalized, blue_normalized
+    )
+
+    if lightness > 0.5:
+        # Bright backdrop: make anchor darker and more saturated
+        adjusted_lightness = max(0.0, lightness - _LIGHTNESS_SHIFT)
+        adjusted_saturation = min(1.0, saturation + _SATURATION_SHIFT)
+    else:
+        # Dark backdrop: make anchor brighter and less saturated
+        adjusted_lightness = min(1.0, lightness + _LIGHTNESS_SHIFT)
+        adjusted_saturation = max(0.0, saturation - _SATURATION_SHIFT)
+
+    adjusted_red, adjusted_green, adjusted_blue = colorsys.hls_to_rgb(
+        hue, adjusted_lightness, adjusted_saturation
+    )
+
+    adjusted_red_int = round(adjusted_red * 255)
+    adjusted_green_int = round(adjusted_green * 255)
+    adjusted_blue_int = round(adjusted_blue * 255)
+
+    return (adjusted_red_int << 24) | (adjusted_green_int << 16) | (adjusted_blue_int << 8) | alpha
 
 
 if QtWidgets is None:

--- a/tests/test_anchor_color_system.py
+++ b/tests/test_anchor_color_system.py
@@ -2357,7 +2357,9 @@ class TestGetScriptBackdropColorsReturnsInts(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertIsInstance(result[0], int,
                               "_get_script_backdrop_colors must return ints, not floats")
-        self.assertEqual(result[0], 0x6f3399ff)
+        expected = _real_colors_module.adjust_color_for_backdrop_contrast(0x6f3399ff)
+        self.assertEqual(result[0], expected,
+                         "_get_script_backdrop_colors must return contrast-adjusted colors")
 
 
 class TestPrefsDialogEditColorPassesCurrentColorToGetColor(unittest.TestCase):
@@ -2423,6 +2425,83 @@ class TestPrefsDialogEditColorPassesCurrentColorToGetColor(unittest.TestCase):
                               "nuke.getColor() must receive an int, not a float")
         self.assertEqual(call_arg, 0x00FF00FF,
                          "nuke.getColor() must be called with the int form of the selected color")
+
+
+# ---------------------------------------------------------------------------
+# COLOR-06: adjust_color_for_backdrop_contrast()
+# ---------------------------------------------------------------------------
+
+class TestAdjustColorForBackdropContrast(unittest.TestCase):
+    """COLOR-06: adjust_color_for_backdrop_contrast() produces a visually distinct anchor color."""
+
+    def _adjusted(self, color_int):
+        import colors
+        return colors.adjust_color_for_backdrop_contrast(color_int)
+
+    def _lightness(self, color_int):
+        """Return HLS lightness (0.0–1.0) of a 0xRRGGBBAA color int."""
+        import colorsys
+        red = (color_int >> 24) & 0xFF
+        green = (color_int >> 16) & 0xFF
+        blue = (color_int >> 8) & 0xFF
+        _hue, lightness, _saturation = colorsys.rgb_to_hls(red / 255.0, green / 255.0, blue / 255.0)
+        return lightness
+
+    def test_bright_backdrop_produces_darker_anchor(self):
+        """A bright backdrop (e.g. light pink) should yield a darker anchor color.
+
+        Note: HLS lightness = (max_channel + min_channel) / 2, so saturated primaries
+        like yellow sit at exactly L=0.5.  Use a de-saturated bright color (light pink)
+        whose HLS lightness is unambiguously > 0.5.
+        """
+        # RGB(255, 204, 204) → HLS lightness ≈ 0.90
+        light_pink = 0xFFCCCCFF
+        adjusted = self._adjusted(light_pink)
+        self.assertLess(
+            self._lightness(adjusted),
+            self._lightness(light_pink),
+            "Anchor should be darker than a bright backdrop",
+        )
+
+    def test_dark_backdrop_produces_brighter_anchor(self):
+        """A dark backdrop (e.g. dark blue) should yield a brighter anchor color."""
+        dark_blue = 0x000066FF
+        adjusted = self._adjusted(dark_blue)
+        self.assertGreater(
+            self._lightness(adjusted),
+            self._lightness(dark_blue),
+            "Anchor should be brighter than a dark backdrop",
+        )
+
+    def test_alpha_byte_preserved(self):
+        """The alpha byte must pass through unchanged."""
+        color_with_alpha = 0x3366CCAB  # alpha = 0xAB
+        adjusted = self._adjusted(color_with_alpha)
+        self.assertEqual(adjusted & 0xFF, 0xAB, "Alpha byte must be preserved")
+
+    def test_result_differs_from_input(self):
+        """The adjusted color must not equal the input color."""
+        test_colors = [0xFF8800FF, 0x223344FF, 0x808080FF, 0x6f3399FF]
+        for color in test_colors:
+            adjusted = self._adjusted(color)
+            self.assertNotEqual(adjusted, color, f"Adjusted color must differ from input {color:#010x}")
+
+    def test_pure_white_does_not_raise(self):
+        """Pure white is a valid bright backdrop — must not raise."""
+        result = self._adjusted(0xFFFFFFFF)
+        self.assertIsInstance(result, int)
+
+    def test_pure_black_does_not_raise(self):
+        """Pure black is a valid dark backdrop — must not raise."""
+        result = self._adjusted(0x000000FF)
+        self.assertIsInstance(result, int)
+
+    def test_result_is_valid_color_int(self):
+        """Result must be a 32-bit unsigned integer (fits in 0x00000000–0xFFFFFFFF)."""
+        for color in [0xFF0000FF, 0x00FF00FF, 0x0000FFFF, 0x6f3399FF]:
+            adjusted = self._adjusted(color)
+            self.assertGreaterEqual(adjusted, 0)
+            self.assertLessEqual(adjusted, 0xFFFFFFFF)
 
 
 if __name__ == '__main__':

--- a/tests/test_anchor_naming.py
+++ b/tests/test_anchor_naming.py
@@ -270,5 +270,93 @@ class TestRegexNoMatchFallback(unittest.TestCase):
         self.assertEqual(result, 'plate')
 
 
+class TestHtmlStrippingInBackdropLabel(unittest.TestCase):
+    """HTML tags in backdrop labels are stripped before use as a name prefix.
+
+    Regression tests for issue #10.
+    """
+
+    def setUp(self):
+        self._original_naming_regex = getattr(prefs_module, 'naming_regex', '')
+        self._original_naming_template = getattr(prefs_module, 'naming_template', '')
+        prefs_module.naming_regex = ''
+        prefs_module.naming_template = ''
+
+    def tearDown(self):
+        prefs_module.naming_regex = self._original_naming_regex
+        prefs_module.naming_template = self._original_naming_template
+
+    def _make_backdrop(self, label):
+        label_knob = StubKnob(value=label, knob_name='label')
+        return StubNode(name='BackdropNode1', node_class='BackdropNode', knobs_dict={'label': label_knob})
+
+    def test_fully_wrapped_html_tags_stripped_from_backdrop_label(self):
+        """<center><b><i>PLATES</i></b></center> in backdrop label becomes PLATES prefix."""
+        node = _make_read_node('shot_v001.exr')
+        backdrop = self._make_backdrop('<center><b><i>PLATES</i></b></center>')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop):
+            result = anchor.suggest_anchor_name(node)
+        self.assertEqual(result, 'PLATES_shot')
+
+    def test_unclosed_html_tag_stripped_from_backdrop_label(self):
+        """<b>PLATES (unclosed tag, valid in Nuke) in backdrop label becomes PLATES prefix."""
+        node = _make_read_node('shot_v001.exr')
+        backdrop = self._make_backdrop('<b>PLATES')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop):
+            result = anchor.suggest_anchor_name(node)
+        self.assertEqual(result, 'PLATES_shot')
+
+    def test_mixed_html_and_plain_text_stripped(self):
+        """Tags interspersed with text are all removed, leaving only plain text."""
+        node = _make_read_node('shot_v001.exr')
+        backdrop = self._make_backdrop('<b>COMP<i>_WORK</i>')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop):
+            result = anchor.suggest_anchor_name(node)
+        self.assertEqual(result, 'COMP_WORK_shot')
+
+    def test_plain_backdrop_label_unchanged(self):
+        """Backdrop labels with no HTML pass through unchanged."""
+        node = _make_read_node('shot_v001.exr')
+        backdrop = self._make_backdrop('PLATES')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=backdrop):
+            result = anchor.suggest_anchor_name(node)
+        self.assertEqual(result, 'PLATES_shot')
+
+
+class TestHtmlStrippingInDotLabel(unittest.TestCase):
+    """HTML tags in Dot node labels are stripped before use as a name suggestion.
+
+    Regression tests for issue #10.
+    """
+
+    def setUp(self):
+        self._original_naming_regex = getattr(prefs_module, 'naming_regex', '')
+        self._original_naming_template = getattr(prefs_module, 'naming_template', '')
+        prefs_module.naming_regex = ''
+        prefs_module.naming_template = ''
+
+    def tearDown(self):
+        prefs_module.naming_regex = self._original_naming_regex
+        prefs_module.naming_template = self._original_naming_template
+
+    def _make_labelled_dot(self, label):
+        label_knob = StubKnob(value=label, knob_name='label')
+        return StubNode(name='Dot1', node_class='Dot', knobs_dict={'label': label_knob})
+
+    def test_html_tags_stripped_from_dot_label(self):
+        """<b>PLATES</b> in a Dot label becomes PLATES."""
+        dot = self._make_labelled_dot('<b>PLATES</b>')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=None):
+            result = anchor.suggest_anchor_name(dot)
+        self.assertEqual(result, 'PLATES')
+
+    def test_unclosed_html_tag_stripped_from_dot_label(self):
+        """<b>PLATES (unclosed) in a Dot label becomes PLATES."""
+        dot = self._make_labelled_dot('<b>PLATES')
+        with patch('anchor.find_smallest_containing_backdrop', return_value=None):
+            result = anchor.suggest_anchor_name(dot)
+        self.assertEqual(result, 'PLATES')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dot_name_suggestion.py
+++ b/tests/test_dot_name_suggestion.py
@@ -20,6 +20,7 @@ if 'nuke' not in sys.modules:
     sys.modules['nuke'] = make_stub_nuke_module()
 
 import anchor
+import colors
 import prefs as prefs_module
 
 
@@ -326,11 +327,14 @@ class TestFindAnchorColorBackdrop(unittest.TestCase):
              patch('anchor.find_node_color', return_value=noop_node_color):
             result = anchor.find_anchor_color(anchor_node)
 
-        self.assertEqual(result, backdrop_color,
-                         "Backdrop color must be used for non-Read inputs (was broken in issue #8)")
+        self.assertEqual(
+            result,
+            colors.adjust_color_for_backdrop_contrast(backdrop_color),
+            "Anchor color must be the contrast-adjusted backdrop color for non-Read inputs",
+        )
 
     def test_read_input_inside_backdrop_still_returns_backdrop_color(self):
-        """Anchor with a Read input inside a backdrop must still return the backdrop color."""
+        """Anchor with a Read input inside a backdrop must return the contrast-adjusted backdrop color."""
         backdrop_color = 0xFF6600FF
         backdrop = self._make_backdrop(backdrop_color)
 
@@ -342,7 +346,7 @@ class TestFindAnchorColorBackdrop(unittest.TestCase):
              patch('anchor.find_node_color', return_value=read_color):
             result = anchor.find_anchor_color(anchor_node)
 
-        self.assertEqual(result, backdrop_color)
+        self.assertEqual(result, colors.adjust_color_for_backdrop_contrast(backdrop_color))
 
     def test_non_read_input_outside_backdrop_returns_node_color(self):
         """Anchor with a non-Read input and no containing backdrop uses the node's color."""


### PR DESCRIPTION
Closes #11

## Summary

- Adds `adjust_color_for_backdrop_contrast()` in `colors.py` — converts the backdrop's `0xRRGGBBAA` color to HLS, shifts lightness ±0.22 and saturation ±0.15 (bright backdrops → darker/more-saturated anchor; dark backdrops → brighter/less-saturated), then converts back. Alpha is preserved unchanged.
- `find_anchor_color()` now returns the adjusted color instead of the raw backdrop color.
- `create_anchor()` pre-fills the color dialog with the adjusted color.
- `_get_script_backdrop_colors()` now yields adjusted colors so the "Backdrop Colors" palette section shows the actual color that will be assigned to an anchor, not the backdrop color itself.

## Test plan

- [ ] 7 new `TestAdjustColorForBackdropContrast` tests covering bright/dark inputs, alpha preservation, edge cases (black, white), and range validity
- [ ] Updated `TestFindAnchorColorBackdrop` and `TestGetScriptBackdropColorsReturnsInts` to expect adjusted colors
- [ ] Full suite: 267 passed, 0 failed