### PR TITLE
fix(#25): prevent exponential re-traversal in upstream_ignoring_hidden

### DIFF
--- a/util.py
+++ b/util.py
@@ -2,17 +2,22 @@ import nuke
 import nukescripts
 
 
-def upstream_ignoring_hidden(node, nodes_so_far=None):
-    inputs = node.dependencies(what=nuke.INPUTS)
-    if len(inputs) == 0:
+def upstream_ignoring_hidden(node, nodes_so_far=None, _visited=None):
+    if _visited is None:
+        _visited = set()
+    if node in _visited:
         return nodes_so_far
+    _visited.add(node)
+
+    inputs = node.dependencies(what=nuke.INPUTS)
+    if not inputs:
+        return nodes_so_far
+    if nodes_so_far is None:
+        nodes_so_far = set(inputs)
     else:
-        if nodes_so_far is None:
-            nodes_so_far = set(inputs)
-        else:
-            nodes_so_far.update(set(inputs))
+        nodes_so_far.update(inputs)
     for input_node in inputs:
-        nodes_so_far.update(upstream_ignoring_hidden(input_node, nodes_so_far))
+        upstream_ignoring_hidden(input_node, nodes_so_far, _visited)
     return nodes_so_far
 
 


### PR DESCRIPTION
Closes #25

## Problem

`upstream_ignoring_hidden` tracked nodes added to the **result** set but had no record of nodes already **traversed**. In diamond-shaped DAGs (one upstream node feeding multiple downstream nodes that reconverge), the same subtree was recursed into once per path reaching it — call count grew as ~2^N shared nodes.

## Fix

Add a `_visited` set so each node is entered at most once. Traversal is now O(nodes) regardless of DAG shape.

Also tidied the function slightly: dropped the unnecessary `else` branch and the redundant `set(inputs)` copy (the set constructor was wrapping an already-iterable list).