### PR TITLE
fix(#28): strip script stem from anchor FQNNs; fix #27 old-format bugs

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -78,6 +78,11 @@ anchors_menu.addCommand(
     "anchors.migrate_to_stemless_names()"
 )
 
+# Automatically migrate old-style knob names on every script load.
+# migrate_script() is idempotent — it only acts when the old knob names are
+# present and the new ones are absent, so repeated loads are no-ops.
+nuke.addOnScriptLoad(anchors.migrate_script)
+
 anchors_menu.addSeparator()
 anchors_menu.addCommand(
     "Anchor Preferences...",

--- a/tests/test_cross_script_paste.py
+++ b/tests/test_cross_script_paste.py
@@ -76,6 +76,16 @@ class TestExtractDisplayNameFromFqnn(unittest.TestCase):
         result = self.extract('shotA.Anchor_')
         self.assertEqual(result, '')
 
+    def test_new_format_single_segment_returns_display_name(self):
+        # Current format: no stem prefix, just the node name
+        result = self.extract('Anchor_MyFootage')
+        self.assertEqual(result, 'MyFootage')
+
+    def test_new_format_group_qualified_returns_last_segment_display_name(self):
+        # Current format: group-qualified without stem, e.g. 'Group1.Anchor_Foo'
+        result = self.extract('Group1.Anchor_MyFootage')
+        self.assertEqual(result, 'MyFootage')
+
 
 # ---------------------------------------------------------------------------
 # Integration tests for paste_anchors() cross-script reconnect behavior

--- a/tests/test_issue27.py
+++ b/tests/test_issue27.py
@@ -1,6 +1,6 @@
 """Regression tests for GitHub issue #27 — Issues with Anchors/Links in Test Script.
 
-Covers four bugs found when using old-format scripts:
+Covers five bugs found when using old-format scripts:
 
   Bug A  create_from_anchor() produced a Dot link when a NoOp anchor's input was a Dot.
   Bug B  (removed) anchors no longer receive FQNNs during copy, so cross-script paste
@@ -9,6 +9,8 @@ Covers four bugs found when using old-format scripts:
          stored in the very-old full-file-path format ("/path/to/script.Anchor_Foo").
   Bug D  reconnect_anchor_node() had a duplicated inline loop that also missed
          old-format links; it now delegates to get_links_for_anchor().
+  Bug E  reconnect_link_node() failed to reconnect when KNOB_NAME held a very-old
+         full-file-path FQNN; fixed by find_anchor_node() stripping the first segment.
 """
 
 import sys
@@ -466,6 +468,52 @@ class TestReconnectAnchorNodeOldFormat(unittest.TestCase):
             anchor_module.reconnect_anchor_node(anchor)
 
         self.assertNotIn(wrong_link, reconnected)
+
+
+# ---------------------------------------------------------------------------
+# Bug E — reconnect_link_node resolves old-format stored FQNNs
+# ---------------------------------------------------------------------------
+
+class TestReconnectLinkNodeOldFormat(unittest.TestCase):
+    """Bug E: reconnect_link_node() must reconnect to the anchor even when the
+    link's KNOB_NAME holds a very-old full-file-path FQNN.
+
+    find_anchor_node() strips the first dot-segment as a backward-compat
+    fallback, so reconnect_link_node() (which calls find_anchor_node()) must
+    also work transparently with old-format stored names.
+    """
+
+    def test_reconnect_link_node_with_old_format_fqnn_sets_input_to_anchor(self):
+        """reconnect_link_node() must wire the link's input to the resolved anchor
+        when KNOB_NAME stores a very-old full-file-path prefix FQNN."""
+        old_format_stored = '/mnt/proj/editorial/script_v008.Anchor_PLATE_fg01'
+        anchor = StubNode(name='Anchor_PLATE_fg01', node_class='NoOp', knobs_dict={})
+        link = _make_link(old_format_stored)
+
+        with patch('link.nuke') as mock_nuke:
+            mock_nuke.toNode.side_effect = (
+                lambda name: anchor if name == 'Anchor_PLATE_fg01' else None
+            )
+
+            from link import reconnect_link_node
+            reconnect_link_node(link)
+
+        self.assertIs(link._input, anchor)
+
+    def test_reconnect_link_node_with_unresolvable_old_format_fqnn_leaves_input_unchanged(self):
+        """reconnect_link_node() must leave the link untouched when the anchor
+        cannot be resolved (orphaned reference)."""
+        old_format_stored = '/mnt/proj/editorial/script_v008.Anchor_DELETED'
+        link = _make_link(old_format_stored)
+        link._input = None
+
+        with patch('link.nuke') as mock_nuke:
+            mock_nuke.toNode.return_value = None
+
+            from link import reconnect_link_node
+            reconnect_link_node(link)
+
+        self.assertIsNone(link._input)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- **#28 — strip script stem from stored anchor names.** `get_fully_qualified_node_name` now returns `node.fullName()` only (no script-stem prefix). Anchors are reconnectable across scripts without the stem getting in the way. Backward-compat fallback in `find_anchor_node`, `get_links_for_anchor`, and `rename_anchor_to` handles all three historical formats: current (`Anchor_Foo`), legacy stem (`scriptStem.Anchor_Foo`), and very-old full-path (`/path/to/script.Anchor_Foo`).
- **#28 — migration tooling.** `migrate_to_stemless_names()` strips stems from stored FQNNs in existing scripts. Exposed as "Anchor Migrate from Old Version" in the Anchors menu. `migrate_script()` (old-style knob rename) is now also registered as `nuke.addOnScriptLoad` so it runs automatically and silently on every script open.
- **#27 — five old-format script bugs fixed.**
  - Bug A: `create_from_anchor` used the input's class instead of the anchor's own class, producing a Dot link for a NoOp anchor.
  - Bug B: Path C in `copy_anchors` stamped the anchor's FQNN onto itself, causing pasted anchors to become broken self-referential links. Path C removed; anchors are no longer touched during copy.
  - Bug C: `get_links_for_anchor` and `rename_anchor_to` missed links stored in very-old full-path format.
  - Bug D: `reconnect_anchor_node` had an inline loop with a hardcoded equality check; now delegates to `get_links_for_anchor`.
  - Bug E: `reconnect_link_node` → `find_anchor_node` now strips the first segment as a fallback so old-format stored FQNNs reconnect correctly.
- **Additional fixes on this branch:** #8, #10, #11, #12, #13, #25.

Closes #27

## Test plan

- [ ] 301 unit tests pass (`pytest tests/`)
- [ ] Open an old-format script (with `scriptStem.Anchor_Foo` stored FQNNs) — verify links reconnect automatically on load without running any migration manually
- [ ] Run "Anchor Migrate from Old Version" on an old script — verify KNOB_NAME values are rewritten to stemless format
- [ ] Copy-paste an anchor — verify it stays an anchor (not replaced by a link)
- [ ] Use "A" shortcut on a NoOp anchor with a Dot input — verify a NoOp link is created, not a Dot
- [ ] Rename an anchor — verify all old-format links update their labels and stored names
- [ ] Reconnect All Links on a script with old-format FQNNs — verify links wire up

🤖 Generated with [Claude Code](https://claude.com/claude-code)