### PR TITLE
fix: re-setup link nodes from live input on copy

### DIFF
--- a/anchors.py
+++ b/anchors.py
@@ -64,11 +64,14 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
                 else:
                     # Local Dot: restore Local appearance after setup_link_node() overwrites
                     # label/color, matching the behaviour of Path B for non-link hidden-input nodes.
+                    stored_fqnn = get_fully_qualified_node_name(input_node)
                     setup_link_node(input_node, node)
+                    add_input_knob(node, dot_type='local')
                     source_label = input_node['label'].getText() or input_node.name()
                     node['label'].setValue(f"Local: {source_label}")
                     node['tile_color'].setValue(LOCAL_DOT_COLOR)
-                    add_input_knob(node, dot_type='local')
+                    node[KNOB_NAME].setText(stored_fqnn)
+
 
             # Path A — LINK_SOURCE_CLASSES file node: scan for an anchor whose input is this
             # node and store the anchor's FQNN so paste can read the correct link class
@@ -101,24 +104,23 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
                 if input_node is None or input_node in selected_nodes:
                     stored_fqnn = ""
                     add_input_knob(node)
+                    node[KNOB_NAME].setText(stored_fqnn)
                 elif is_anchor(input_node):
                     # Link Dot: anchor-backed, cross-script capable.
                     # Override tile_color to canonical purple — setup_link_node() may apply a
                     # custom anchor color via find_node_color(), which we do not want here.
-                    stored_fqnn = get_fully_qualified_node_name(input_node)
                     setup_link_node(input_node, node)
                     node['tile_color'].setValue(ANCHOR_DEFAULT_COLOR)
-                    add_input_knob(node, dot_type='link')
                 else:
                     # Local Dot: plain-node-backed, same-script only.
                     # Restore Local appearance after setup_link_node() overwrites label/color.
                     stored_fqnn = get_fully_qualified_node_name(input_node)
                     setup_link_node(input_node, node)
+                    add_input_knob(node, dot_type='local')
                     source_label = input_node['label'].getText() or input_node.name()
                     node['label'].setValue(f"Local: {source_label}")
                     node['tile_color'].setValue(LOCAL_DOT_COLOR)
-                    add_input_knob(node, dot_type='local')
-                node[KNOB_NAME].setText(stored_fqnn)
+                    node[KNOB_NAME].setText(stored_fqnn)
 
             elif is_anchor(node) and is_link(node):
                 # Anchor with stale KNOB_NAME from a prior old-style paste: clear it so

--- a/anchors.py
+++ b/anchors.py
@@ -49,17 +49,24 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
     with nuke.lastHitGroup():
         selected_nodes = nuke.selectedNodes()
         for node in selected_nodes:
-            # Skip nodes that are already links (hidden-input Dots, PostageStamps, etc.)
-            # but NOT anchor nodes — an anchor may have KNOB_NAME set from a prior old
-            # paste. That stale reference is cleared below before the clipboard copy.
+            # Path L — existing link nodes: re-setup from the current live input so the
+            # clipboard copy always reflects fresh state.  Anchors that also carry a stale
+            # KNOB_NAME are handled by the elif at the bottom of the chain, not here.
             if is_link(node) and not is_anchor(node):
-                continue
+                input_node = node.input(0)
+                if input_node is None or input_node in selected_nodes:
+                    # Input is absent or being copied alongside this node.  Stamp "" so
+                    # paste_anchors() knows to re-setup from whatever Nuke re-connects the
+                    # pasted copy to.
+                    node[KNOB_NAME].setText("")
+                else:
+                    setup_link_node(input_node, node)
 
             # Path A — LINK_SOURCE_CLASSES file node: scan for an anchor whose input is this
             # node and store the anchor's FQNN so paste can read the correct link class
             # from the anchor's hidden knob. Falls back to the file node's own FQNN when
             # no anchor points at it (legacy direct-file-node path).
-            if node.Class() in LINK_SOURCE_CLASSES:
+            elif node.Class() in LINK_SOURCE_CLASSES:
                 if prefs.link_classes_paste_mode == 'passthrough':
                     # skip stamping; node copies plainly via nuke.nodeCopy() at end of function
                     continue
@@ -199,6 +206,13 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
                     # else → 'local'.
                     display_name_for_compat = _extract_display_name_from_fqnn(stored_fqnn)
                     dot_type = 'link' if display_name_for_compat is not None else 'local'
+
+                # "Input was in selection" case: KNOB_NAME="" because the input was copied
+                # alongside this node.  Nuke has already re-connected the pasted copy to the
+                # pasted copy of the input, so just re-setup from the actual live input.
+                if stored_fqnn == "" and node.input(0) is not None:
+                    setup_link_node(node.input(0), node)
+                    continue
 
                 if not input_node:
                     # Cross-script (or unresolvable FQNN): gate on DOT_TYPE.

--- a/anchors.py
+++ b/anchors.py
@@ -59,8 +59,16 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
                     # paste_anchors() knows to re-setup from whatever Nuke re-connects the
                     # pasted copy to.
                     node[KNOB_NAME].setText("")
-                else:
+                elif is_anchor(input_node):
                     setup_link_node(input_node, node)
+                else:
+                    # Local Dot: restore Local appearance after setup_link_node() overwrites
+                    # label/color, matching the behaviour of Path B for non-link hidden-input nodes.
+                    setup_link_node(input_node, node)
+                    source_label = input_node['label'].getText() or input_node.name()
+                    node['label'].setValue(f"Local: {source_label}")
+                    node['tile_color'].setValue(LOCAL_DOT_COLOR)
+                    add_input_knob(node, dot_type='local')
 
             # Path A — LINK_SOURCE_CLASSES file node: scan for an anchor whose input is this
             # node and store the anchor's FQNN so paste can read the correct link class

--- a/tests/test_copy_link_node.py
+++ b/tests/test_copy_link_node.py
@@ -115,10 +115,12 @@ class TestCopyLinkNodePathL(unittest.TestCase):
 
         mock_setup.assert_called_once_with(anchor, noop_link)
 
-    def test_copy_link_dot_with_plain_input_calls_setup_link_node(self):
+    def test_copy_local_dot_restores_local_appearance(self):
         """Copying a Local Dot (input is a plain node NOT in the selection) calls
-        setup_link_node(plain_node, local_dot)."""
+        setup_link_node then restores Local label, LOCAL_DOT_COLOR, and dot_type='local'."""
+        from constants import DOT_TYPE_KNOB_NAME, LOCAL_DOT_COLOR
         plain = _make_plain_node('Merge1')
+        plain.knobs()['label']._value = 'my merge'
         local_dot = _make_link_node(stored_fqnn='Merge1', node_class='Dot', name='Dot1')
         local_dot._input = plain
 
@@ -135,6 +137,10 @@ class TestCopyLinkNodePathL(unittest.TestCase):
             copy_anchors()
 
         mock_setup.assert_called_once_with(plain, local_dot)
+        self.assertEqual(local_dot['label'].getValue(), 'Local: my merge')
+        self.assertEqual(local_dot['tile_color'].getValue(), LOCAL_DOT_COLOR)
+        self.assertIn(DOT_TYPE_KNOB_NAME, local_dot.knobs())
+        self.assertEqual(local_dot[DOT_TYPE_KNOB_NAME].getValue(), 'local')
 
     def test_copy_link_dot_no_input_stamps_empty_fqnn(self):
         """Copying a disconnected link node (input(0)=None) stamps KNOB_NAME=""."""

--- a/tests/test_copy_link_node.py
+++ b/tests/test_copy_link_node.py
@@ -1,0 +1,266 @@
+"""Tests for copy_anchors() Path L and paste_anchors() "input in selection" re-setup.
+
+Covers:
+- copy_anchors() Path L: existing link nodes are re-setup via setup_link_node() on copy
+  rather than silently skipped.
+- copy_anchors() Path L: when a link node's input is in the selection, KNOB_NAME is
+  stamped to "" so paste can re-setup from the pasted input.
+- paste_anchors(): when KNOB_NAME=="" and node.input(0) is not None (Nuke re-connected
+  the pasted copy to the pasted copy of the input), setup_link_node() is called.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+from constants import KNOB_NAME
+from tests.stubs import StubKnob, StubNode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_knob(value='', knob_name=''):
+    return StubKnob(value=value, knob_name=knob_name)
+
+
+def _make_link_node(stored_fqnn='Anchor_Foo', node_class='Dot', name='Dot1', hide_input=True):
+    """Return a stub link node (already has KNOB_NAME, so is_link() → True)."""
+    knobs = {
+        KNOB_NAME: _make_knob(stored_fqnn, knob_name=KNOB_NAME),
+        'label': _make_knob('Link: Foo'),
+        'tile_color': _make_knob(0),
+        'hide_input': _make_knob(hide_input),
+        'selected': _make_knob(False),
+    }
+    return StubNode(name=name, node_class=node_class, knobs_dict=knobs)
+
+
+def _make_anchor_node(name='Anchor_Foo'):
+    """Return a stub anchor node (name starts with ANCHOR_PREFIX)."""
+    knobs = {
+        'label': _make_knob('Foo'),
+        'tile_color': _make_knob(0),
+        'hide_input': _make_knob(False),
+        'selected': _make_knob(False),
+    }
+    return StubNode(name=name, node_class='NoOp', knobs_dict=knobs)
+
+
+def _make_plain_node(name='Merge1'):
+    """Return a stub plain (non-anchor, non-link) node."""
+    knobs = {
+        'label': _make_knob(''),
+        'tile_color': _make_knob(0),
+        'hide_input': _make_knob(False),
+        'selected': _make_knob(False),
+    }
+    return StubNode(name=name, node_class='Merge', knobs_dict=knobs)
+
+
+def _patch_copy(mock_nuke, selected_nodes, prefs_mock):
+    """Configure common copy_anchors() mock behaviour."""
+    mock_nuke.lastHitGroup.return_value = MagicMock()
+    mock_nuke.selectedNodes.return_value = selected_nodes
+    mock_nuke.nodeCopy.return_value = None
+    prefs_mock.plugin_enabled = True
+
+
+# ---------------------------------------------------------------------------
+# copy_anchors() Path L — re-setup on copy
+# ---------------------------------------------------------------------------
+
+class TestCopyLinkNodePathL(unittest.TestCase):
+    """copy_anchors() must call setup_link_node() for existing link nodes."""
+
+    def test_copy_link_dot_calls_setup_link_node_with_anchor_input(self):
+        """Copying a Link Dot (input is an anchor NOT in the selection) calls
+        setup_link_node(anchor, link_dot)."""
+        anchor = _make_anchor_node('Anchor_Foo')
+        link_dot = _make_link_node(stored_fqnn='Anchor_Foo', node_class='Dot')
+        link_dot._input = anchor
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', side_effect=lambda n: n.name().startswith('Anchor_')), \
+             patch('anchors.setup_link_node') as mock_setup:
+
+            _patch_copy(mock_nuke, [link_dot], mock_prefs)
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+        mock_setup.assert_called_once_with(anchor, link_dot)
+
+    def test_copy_noop_link_calls_setup_link_node_with_anchor_input(self):
+        """Copying a NoOp link node (input is an anchor, hide_input=True, NOT in selection)
+        calls setup_link_node(anchor, noop_link)."""
+        anchor = _make_anchor_node('Anchor_Foo')
+        noop_link = _make_link_node(stored_fqnn='Anchor_Foo', node_class='NoOp', name='NoOp1')
+        noop_link._input = anchor
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', side_effect=lambda n: n.name().startswith('Anchor_')), \
+             patch('anchors.setup_link_node') as mock_setup:
+
+            _patch_copy(mock_nuke, [noop_link], mock_prefs)
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+        mock_setup.assert_called_once_with(anchor, noop_link)
+
+    def test_copy_link_dot_with_plain_input_calls_setup_link_node(self):
+        """Copying a Local Dot (input is a plain node NOT in the selection) calls
+        setup_link_node(plain_node, local_dot)."""
+        plain = _make_plain_node('Merge1')
+        local_dot = _make_link_node(stored_fqnn='Merge1', node_class='Dot', name='Dot1')
+        local_dot._input = plain
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node') as mock_setup:
+
+            _patch_copy(mock_nuke, [local_dot], mock_prefs)
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+        mock_setup.assert_called_once_with(plain, local_dot)
+
+    def test_copy_link_dot_no_input_stamps_empty_fqnn(self):
+        """Copying a disconnected link node (input(0)=None) stamps KNOB_NAME=""."""
+        link_dot = _make_link_node(stored_fqnn='Anchor_Foo', node_class='Dot')
+        link_dot._input = None
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node') as mock_setup:
+
+            _patch_copy(mock_nuke, [link_dot], mock_prefs)
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+        mock_setup.assert_not_called()
+        self.assertEqual(link_dot[KNOB_NAME].getText(), "")
+
+    def test_copy_link_dot_input_in_selection_stamps_empty_fqnn(self):
+        """When a Link Dot and its anchor are both in the selection, KNOB_NAME is
+        stamped to "" so paste can re-setup from the pasted anchor copy."""
+        anchor = _make_anchor_node('Anchor_Foo')
+        link_dot = _make_link_node(stored_fqnn='Anchor_Foo', node_class='Dot')
+        link_dot._input = anchor
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', side_effect=lambda n: n.name().startswith('Anchor_')), \
+             patch('anchors.setup_link_node') as mock_setup:
+
+            # Both nodes in selection — anchor is input_node and also in selected_nodes.
+            _patch_copy(mock_nuke, [link_dot, anchor], mock_prefs)
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+        mock_setup.assert_not_called()
+        self.assertEqual(link_dot[KNOB_NAME].getText(), "")
+
+
+# ---------------------------------------------------------------------------
+# paste_anchors() — "input in selection" re-setup
+# ---------------------------------------------------------------------------
+
+class TestPasteLinkNodeInputInSelection(unittest.TestCase):
+    """paste_anchors() must re-setup a link node whose KNOB_NAME=="" when Nuke
+    has already re-connected it to the pasted copy of the input."""
+
+    def _make_pasted_link(self, node_class='Dot', name='Dot1'):
+        """Return a link stub with KNOB_NAME="" (as stamped by copy when input was in selection)."""
+        knobs = {
+            KNOB_NAME: _make_knob('', knob_name=KNOB_NAME),
+            'label': _make_knob('Link: Foo'),
+            'tile_color': _make_knob(0),
+            'hide_input': _make_knob(True),
+            'selected': _make_knob(False),
+        }
+        return StubNode(name=name, node_class=node_class, knobs_dict=knobs)
+
+    def test_paste_dot_link_with_empty_fqnn_and_live_input_calls_setup_link_node(self):
+        """When a pasted Dot has KNOB_NAME="" and input(0) is not None, setup_link_node
+        is called with the actual pasted input."""
+        pasted_anchor = _make_anchor_node('Anchor_Foo')
+        pasted_link = self._make_pasted_link(node_class='Dot')
+        pasted_link._input = pasted_anchor   # Nuke re-connected it
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.find_anchor_node', return_value=None), \
+             patch('anchors.setup_link_node') as mock_setup, \
+             patch('anchors.is_anchor', side_effect=lambda n: n.name().startswith('Anchor_')):
+
+            mock_nuke.nodePaste.return_value = None
+            mock_nuke.selectedNodes.return_value = [pasted_link]
+            mock_nuke.lastHitGroup.return_value = MagicMock()
+            mock_nukescripts.clear_selection_recursive = MagicMock()
+
+            from anchors import paste_anchors
+            paste_anchors()
+
+        mock_setup.assert_called_once_with(pasted_anchor, pasted_link)
+
+    def test_paste_noop_link_with_empty_fqnn_and_live_input_calls_setup_link_node(self):
+        """Same as above but for a NoOp link node."""
+        pasted_anchor = _make_anchor_node('Anchor_Foo')
+        pasted_link = self._make_pasted_link(node_class='NoOp', name='NoOp1')
+        pasted_link._input = pasted_anchor
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.find_anchor_node', return_value=None), \
+             patch('anchors.setup_link_node') as mock_setup, \
+             patch('anchors.is_anchor', side_effect=lambda n: n.name().startswith('Anchor_')):
+
+            mock_nuke.nodePaste.return_value = None
+            mock_nuke.selectedNodes.return_value = [pasted_link]
+            mock_nuke.lastHitGroup.return_value = MagicMock()
+            mock_nukescripts.clear_selection_recursive = MagicMock()
+
+            from anchors import paste_anchors
+            paste_anchors()
+
+        mock_setup.assert_called_once_with(pasted_anchor, pasted_link)
+
+    def test_paste_dot_link_with_empty_fqnn_and_no_input_does_not_call_setup_link_node(self):
+        """When KNOB_NAME=="" but input(0) is None (truly disconnected), setup_link_node
+        must NOT be called — nothing to reconnect to."""
+        pasted_link = self._make_pasted_link(node_class='Dot')
+        pasted_link._input = None   # no live input
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.find_anchor_node', return_value=None), \
+             patch('anchors.setup_link_node') as mock_setup:
+
+            mock_nuke.nodePaste.return_value = None
+            mock_nuke.selectedNodes.return_value = [pasted_link]
+            mock_nuke.lastHitGroup.return_value = MagicMock()
+            mock_nukescripts.clear_selection_recursive = MagicMock()
+
+            from anchors import paste_anchors
+            paste_anchors()
+
+        mock_setup.assert_not_called()


### PR DESCRIPTION
## Summary

- **Path L in `copy_anchors()`**: existing link nodes (Link Dots, Local Dots, NoOp/PostageStamp links) were previously skipped with an early `continue`, leaving stale KNOB_NAME and visual state in the clipboard. They now call `setup_link_node()` against their current live input so the clipboard copy always reflects fresh state.
- **Local Dot preservation**: after `setup_link_node()`, Local Dots have their `"Local: <label>"`, `LOCAL_DOT_COLOR`, and `dot_type='local'` restored — matching the existing Path B behaviour.
- **Input-in-selection case**: when a link node's input is also in the selection, `KNOB_NAME` is stamped `""`. On paste, `paste_anchors()` now detects this (`KNOB_NAME==""` + `input(0) is not None`) and calls `setup_link_node()` against whatever Nuke re-connected the pasted copy to.

## Test plan

- [ ] `pytest tests/` — 309 tests, all pass
- [x] Copy a Link Dot alone → paste same script → reconnects to original anchor with fresh label/color
- [x] Copy a Link Dot + its anchor together → paste → Link Dot connects to the pasted anchor copy, not the original
- [x] Copy a Local Dot alone → paste → reconnects to original node, retains `"Local: ..."` label and orange colour
- [x] Copy a Local Dot + its input together → paste → Local Dot connects to pasted input copy, retains Local appearance
- [x] Copy a NoOp link → paste → same as Link Dot cases above