### PR TITLE
fix: local dots store script stem in FQNN to prevent cross-script reconnect

### DIFF
--- a/anchors.py
+++ b/anchors.py
@@ -66,7 +66,8 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
                 else:
                     # Local Dot: restore Local appearance after setup_link_node() overwrites
                     # label/color, matching the behaviour of Path B for non-link hidden-input nodes.
-                    stored_fqnn = get_fully_qualified_node_name(input_node)
+                    script_stem = nuke.root().name().split('.')[0]
+                    stored_fqnn = f"{script_stem}.{get_fully_qualified_node_name(input_node)}"
                     setup_link_node(input_node, node)
                     add_input_knob(node, dot_type='local')
                     source_label = input_node['label'].getText() or input_node.name()
@@ -117,7 +118,8 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
                 else:
                     # Local Dot: plain-node-backed, same-script only.
                     # Restore Local appearance after setup_link_node() overwrites label/color.
-                    stored_fqnn = get_fully_qualified_node_name(input_node)
+                    script_stem = nuke.root().name().split('.')[0]
+                    stored_fqnn = f"{script_stem}.{get_fully_qualified_node_name(input_node)}"
                     setup_link_node(input_node, node)
                     add_input_knob(node, dot_type='local')
                     source_label = input_node['label'].getText() or input_node.name()
@@ -173,6 +175,26 @@ def _extract_display_name_from_fqnn(stored_fqnn):
     if node_full_name.startswith(ANCHOR_PREFIX):
         return node_full_name[len(ANCHOR_PREFIX):]
     return None
+
+
+def _find_local_node(stored_fqnn):
+    """Resolve a local-dot FQNN to a live node, enforcing same-script guard.
+
+    Expects "scriptStem.nodeFullName" format.  Returns the node when the stem
+    matches the current script; returns None for a different stem (cross-script)
+    or for any FQNN without a dot (defensively handles pre-fix nodes that are
+    restamped at copy time before being pasted).
+    """
+    if not stored_fqnn:
+        return None
+    parts = stored_fqnn.split('.', 1)
+    if len(parts) != 2:
+        return None
+    script_stem, node_name = parts
+    current_stem = nuke.root().name().split('.')[0]
+    if script_stem != current_stem:
+        return None
+    return nuke.toNode(node_name)
 
 
 def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot paths × same/cross-script gate
@@ -255,6 +277,9 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
                     # else → 'local'.
                     display_name_for_compat = _extract_display_name_from_fqnn(stored_fqnn)
                     dot_type = 'link' if display_name_for_compat is not None else 'local'
+
+                if dot_type == 'local':
+                    input_node = _find_local_node(stored_fqnn)
 
                 # "Input was in selection" case: KNOB_NAME="" because the input was copied
                 # alongside this node.  Nuke has already re-connected the pasted copy to the

--- a/anchors.py
+++ b/anchors.py
@@ -5,6 +5,8 @@ Configure which node classes trigger link replacement by editing LINK_SOURCE_CLA
 in constants.py.
 """
 
+import os
+
 import nuke
 import nukescripts
 
@@ -27,6 +29,12 @@ from link import (
     is_link,
     setup_link_node,
 )
+
+
+def _get_script_stem():
+    # os.path.splitext handles multi-dot names like "project.shotA.nk" → "project.shotA"
+    # whereas split('.')[0] would give the ambiguous "project" for both shotA and shotB.
+    return os.path.splitext(os.path.basename(nuke.root().name()))[0]
 
 
 def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-class paths × same/cross-script gate
@@ -66,7 +74,7 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
                 else:
                     # Local Dot: restore Local appearance after setup_link_node() overwrites
                     # label/color, matching the behaviour of Path B for non-link hidden-input nodes.
-                    script_stem = nuke.root().name().split('.')[0]
+                    script_stem = _get_script_stem()
                     stored_fqnn = f"{script_stem}.{get_fully_qualified_node_name(input_node)}"
                     setup_link_node(input_node, node)
                     add_input_knob(node, dot_type='local')
@@ -118,7 +126,7 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
                 else:
                     # Local Dot: plain-node-backed, same-script only.
                     # Restore Local appearance after setup_link_node() overwrites label/color.
-                    script_stem = nuke.root().name().split('.')[0]
+                    script_stem = _get_script_stem()
                     stored_fqnn = f"{script_stem}.{get_fully_qualified_node_name(input_node)}"
                     setup_link_node(input_node, node)
                     add_input_knob(node, dot_type='local')
@@ -185,14 +193,14 @@ def _find_local_node(stored_fqnn):
     or for any FQNN without a dot (defensively handles pre-fix nodes that are
     restamped at copy time before being pasted).
     """
-    if not stored_fqnn:
+    if not stored_fqnn or '.' not in stored_fqnn:
         return None
-    parts = stored_fqnn.split('.', 1)
-    if len(parts) != 2:
+    current_stem = _get_script_stem()
+    prefix = current_stem + '.'
+    if not stored_fqnn.startswith(prefix):
         return None
-    script_stem, node_name = parts
-    current_stem = nuke.root().name().split('.')[0]
-    if script_stem != current_stem:
+    node_name = stored_fqnn[len(prefix):]
+    if not node_name:
         return None
     return nuke.toNode(node_name)
 
@@ -216,12 +224,11 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
                 # we haven't stored any info on this node, do nothing
                 continue
 
-            input_node = find_anchor_node(node)
-
             if node.Class() in LINK_SOURCE_CLASSES:
                 # Path A: file node pasted → replace with a link node.
                 # find_anchor_node() resolves the stored FQNN; None means cross-script or
                 # deleted.
+                input_node = find_anchor_node(node)
                 if not input_node:
                     # Cross-script (or deleted) case: find_anchor_node() returned None.
                     # File nodes are left disconnected as placeholders.
@@ -245,6 +252,7 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
                 # on old-style stale-KNOB_NAME anchors (which must remain as-is per BUG-02).
                 # Path D is checked before Path B because NoOp is in HIDDEN_INPUT_CLASSES;
                 # without this ordering a stamped anchor NoOp would enter Path B instead.
+                input_node = find_anchor_node(node)
                 if not input_node:
                     # Cross-script (or unresolvable FQNN): attempt name-based fallback.
                     # KNOB_NAME is guaranteed present here — we passed the top-of-loop guard.
@@ -280,6 +288,8 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
 
                 if dot_type == 'local':
                     input_node = _find_local_node(stored_fqnn)
+                else:
+                    input_node = find_anchor_node(node)
 
                 # "Input was in selection" case: KNOB_NAME="" because the input was copied
                 # alongside this node.  Nuke has already re-connected the pasted copy to the

--- a/tests/test_copy_link_node.py
+++ b/tests/test_copy_link_node.py
@@ -132,6 +132,7 @@ class TestCopyLinkNodePathL(unittest.TestCase):
              patch('anchors.setup_link_node') as mock_setup:
 
             _patch_copy(mock_nuke, [local_dot], mock_prefs)
+            mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
 
             from anchors import copy_anchors
             copy_anchors()

--- a/tests/test_dot_type_distinction.py
+++ b/tests/test_dot_type_distinction.py
@@ -462,6 +462,37 @@ class TestFindLocalNode(unittest.TestCase):
         self.assertIs(result, found_node)
         mock_nuke.toNode.assert_called_once_with('Group1.ReadNode1')
 
+    def test_multi_dot_script_name_same_stem_returns_node(self):
+        """'project.shotA.nk' → stem 'project.shotA'; FQNN 'project.shotA.Blur1' resolves."""
+        from anchors import _find_local_node
+
+        found_node = _make_stub_node(name='Blur1', node_class='Blur')
+
+        with patch('anchors.nuke') as mock_nuke:
+            root_obj = MagicMock()
+            root_obj.name.return_value = 'project.shotA.nk'
+            mock_nuke.root.return_value = root_obj
+            mock_nuke.toNode.return_value = found_node
+
+            result = _find_local_node('project.shotA.Blur1')
+
+        self.assertIs(result, found_node)
+        mock_nuke.toNode.assert_called_once_with('Blur1')
+
+    def test_multi_dot_script_name_different_stem_returns_none(self):
+        """'project.shotA.nk' and 'project.shotB.Blur1' have distinct full stems — no reconnect."""
+        from anchors import _find_local_node
+
+        with patch('anchors.nuke') as mock_nuke:
+            root_obj = MagicMock()
+            root_obj.name.return_value = 'project.shotA.nk'
+            mock_nuke.root.return_value = root_obj
+
+            result = _find_local_node('project.shotB.Blur1')
+
+        self.assertIsNone(result)
+        mock_nuke.toNode.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Tests for paste_anchors() Path B cross-script DOT_TYPE behavior
@@ -754,7 +785,7 @@ class TestPasteHiddenSameScriptDotTypeBehavior(unittest.TestCase):
 
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
-             patch('anchors.find_anchor_node', return_value=source_node), \
+             patch('anchors.find_anchor_node') as mock_find_anchor_node, \
              patch('anchors.find_anchor_by_name') as mock_find_by_name, \
              patch('anchors.setup_link_node') as mock_setup_link_node, \
              patch('anchors.is_anchor', return_value=False):
@@ -768,6 +799,9 @@ class TestPasteHiddenSameScriptDotTypeBehavior(unittest.TestCase):
 
             from anchors import paste_anchors
             paste_anchors()
+
+            # Local dots use _find_local_node(), not find_anchor_node()
+            mock_find_anchor_node.assert_not_called()
 
             # setup_link_node must be called for same-script reconnect
             mock_setup_link_node.assert_called_once_with(source_node, dot_node)
@@ -893,7 +927,7 @@ class TestPasteHiddenSameScriptDotTypeKnobPreservation(unittest.TestCase):
 
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
-             patch('anchors.find_anchor_node', return_value=source_node), \
+             patch('anchors.find_anchor_node') as mock_find_anchor_node, \
              patch('anchors.setup_link_node') as mock_setup_link_node, \
              patch('anchors.add_input_knob') as mock_add_input_knob, \
              patch('anchors.is_anchor', return_value=False):
@@ -907,6 +941,9 @@ class TestPasteHiddenSameScriptDotTypeKnobPreservation(unittest.TestCase):
 
             from anchors import paste_anchors
             paste_anchors()
+
+            # Local dots use _find_local_node(), not find_anchor_node()
+            mock_find_anchor_node.assert_not_called()
 
             # add_input_knob must be called with dot_type='local' to re-stamp the knob
             mock_add_input_knob.assert_called_once_with(dot_node, dot_type='local')

--- a/tests/test_dot_type_distinction.py
+++ b/tests/test_dot_type_distinction.py
@@ -285,9 +285,10 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
              patch('anchors.setup_link_node'), \
              patch('anchors.add_input_knob') as mock_add_input_knob, \
              patch('anchors.get_fully_qualified_node_name',
-                   return_value='sourceScript.Blur1'):
+                   return_value='Blur1'):
 
             mock_nuke.selectedNodes.return_value = [dot_node]
+            mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
 
             from anchors import copy_anchors
             copy_anchors()
@@ -308,9 +309,10 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
              patch('anchors.setup_link_node'), \
              patch('anchors.add_input_knob'), \
              patch('anchors.get_fully_qualified_node_name',
-                   return_value='sourceScript.Blur1'):
+                   return_value='Blur1'):
 
             mock_nuke.selectedNodes.return_value = [dot_node]
+            mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
 
             from anchors import copy_anchors
             copy_anchors()
@@ -337,9 +339,10 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
              patch('anchors.setup_link_node'), \
              patch('anchors.add_input_knob'), \
              patch('anchors.get_fully_qualified_node_name',
-                   return_value='sourceScript.Blur1'):
+                   return_value='Blur1'):
 
             mock_nuke.selectedNodes.return_value = [dot_node]
+            mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
 
             from anchors import copy_anchors
             copy_anchors()
@@ -349,6 +352,115 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
                 LOCAL_DOT_COLOR,
                 "Plain-node-backed Dot tile_color must be set to LOCAL_DOT_COLOR (burnt orange)"
             )
+
+    def test_copy_hidden_plain_node_backed_dot_stores_script_qualified_fqnn(self):
+        """copy_anchors() on plain-node-backed Dot must store 'scriptStem.nodeFullName'
+        in KNOB_NAME so that paste can enforce the same-script guard."""
+        from constants import KNOB_NAME
+
+        dot_node = self._make_dot_node_with_hide_input()
+        plain_input_node = _make_stub_node(name='Blur1', node_class='Blur',
+                                           knobs_dict={'label': _make_knob('')})
+        dot_node._input = plain_input_node
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.is_link', return_value=False), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node'), \
+             patch('anchors.add_input_knob'), \
+             patch('anchors.get_fully_qualified_node_name',
+                   return_value='Blur1'):
+
+            mock_nuke.selectedNodes.return_value = [dot_node]
+            mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+            self.assertEqual(
+                dot_node[KNOB_NAME].getValue(),
+                'sourceScript.Blur1',
+                "Local Dot KNOB_NAME must be 'scriptStem.nodeFullName' after copy"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests for _find_local_node() helper
+# ---------------------------------------------------------------------------
+
+class TestFindLocalNode(unittest.TestCase):
+    """Unit tests for the _find_local_node() script-stem-aware lookup helper."""
+
+    def test_same_stem_returns_node(self):
+        """Returns the resolved node when the FQNN stem matches the current script."""
+        from anchors import _find_local_node
+
+        found_node = _make_stub_node(name='Blur1', node_class='Blur')
+
+        with patch('anchors.nuke') as mock_nuke:
+            root_obj = MagicMock()
+            root_obj.name.return_value = 'shotA.nk'
+            mock_nuke.root.return_value = root_obj
+            mock_nuke.toNode.return_value = found_node
+
+            result = _find_local_node('shotA.Blur1')
+
+        self.assertIs(result, found_node)
+        mock_nuke.toNode.assert_called_once_with('Blur1')
+
+    def test_different_stem_returns_none(self):
+        """Returns None when the FQNN stem differs from the current script (cross-script)."""
+        from anchors import _find_local_node
+
+        with patch('anchors.nuke') as mock_nuke:
+            root_obj = MagicMock()
+            root_obj.name.return_value = 'destScript.nk'
+            mock_nuke.root.return_value = root_obj
+            mock_nuke.toNode.return_value = _make_stub_node(name='Blur1', node_class='Blur')
+
+            result = _find_local_node('sourceScript.Blur1')
+
+        self.assertIsNone(result)
+        mock_nuke.toNode.assert_not_called()
+
+    def test_empty_fqnn_returns_none(self):
+        """Returns None for an empty FQNN without calling nuke.root()."""
+        from anchors import _find_local_node
+
+        with patch('anchors.nuke') as mock_nuke:
+            result = _find_local_node('')
+
+        self.assertIsNone(result)
+        mock_nuke.root.assert_not_called()
+
+    def test_no_stem_returns_none(self):
+        """Returns None for a stemless FQNN (single segment, no dot) — cannot verify same-script."""
+        from anchors import _find_local_node
+
+        with patch('anchors.nuke') as mock_nuke:
+            result = _find_local_node('Blur1')
+
+        self.assertIsNone(result)
+        mock_nuke.root.assert_not_called()
+        mock_nuke.toNode.assert_not_called()
+
+    def test_group_nested_node_same_stem_returns_node(self):
+        """Group-nested FQNN like 'stem.Group1.ReadNode1' strips only the stem."""
+        from anchors import _find_local_node
+
+        found_node = _make_stub_node(name='ReadNode1', node_class='Read')
+
+        with patch('anchors.nuke') as mock_nuke:
+            root_obj = MagicMock()
+            root_obj.name.return_value = 'shotA.nk'
+            mock_nuke.root.return_value = root_obj
+            mock_nuke.toNode.return_value = found_node
+
+            result = _find_local_node('shotA.Group1.ReadNode1')
+
+        self.assertIs(result, found_node)
+        mock_nuke.toNode.assert_called_once_with('Group1.ReadNode1')
 
 
 # ---------------------------------------------------------------------------
@@ -460,29 +572,24 @@ class TestPasteHiddenCrossScriptDotTypeBehavior(unittest.TestCase):
             mock_find_by_name.assert_not_called()
             mock_setup_link_node.assert_not_called()
 
-    def test_local_dot_reconnects_when_find_anchor_node_resolves_a_node(self):
-        """Local Dot reconnects to whatever node find_anchor_node() resolves in the
-        current script context.  GitHub #28 removed stem-based cross-script detection,
-        so if a same-named node exists in the destination it is used regardless of
-        which script the Dot originated from."""
+    def test_local_dot_no_stem_fqnn_does_not_reconnect(self):
+        """Local Dot with a stemless FQNN (old format, no script prefix) must NOT reconnect.
+
+        _find_local_node() requires "stem.name" format to verify same-script; a bare
+        node name carries no provenance information so the safe choice is no reconnect.
+        Old-format nodes are restamped with the script stem at copy time before any
+        paste can occur, so this case is purely defensive."""
 
         dot_node = self._make_hidden_dot_node(
-            stored_fqnn='Blur1',  # new format: no script stem
+            stored_fqnn='Blur1',  # no script stem
             dot_type='local'
-        )
-
-        matching_node = _make_stub_node(
-            name='Blur1',
-            node_class='Blur',
-            knobs_dict={'label': _make_knob('')},
         )
 
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
-             patch('anchors.find_anchor_node', return_value=matching_node), \
+             patch('anchors.find_anchor_node', return_value=None), \
              patch('anchors.find_anchor_by_name') as mock_find_by_name, \
              patch('anchors.setup_link_node') as mock_setup_link_node, \
-             patch('anchors.add_input_knob'), \
              patch('anchors.is_anchor', return_value=False):
 
             mock_nuke.nodePaste.return_value = None
@@ -491,8 +598,42 @@ class TestPasteHiddenCrossScriptDotTypeBehavior(unittest.TestCase):
             from anchors import paste_anchors
             paste_anchors()
 
-            # Local Dot reconnects to the resolved node; name-based anchor search is not used
-            mock_setup_link_node.assert_called_once_with(matching_node, dot_node)
+            mock_setup_link_node.assert_not_called()
+            mock_find_by_name.assert_not_called()
+
+    def test_local_dot_cross_script_false_positive_does_not_reconnect(self):
+        """Local Dot pasted cross-script must NOT reconnect even when a same-named node
+        exists in the destination script.
+
+        This is the key regression for issue #33: previously _find_local_node was absent
+        and find_anchor_node() would resolve a same-named node in the destination,
+        causing an unintended cross-script reconnect."""
+        dot_node = self._make_hidden_dot_node(
+            stored_fqnn='sourceScript.Blur1',
+            dot_type='local'
+        )
+
+        same_named_dest_node = _make_stub_node(name='Blur1', node_class='Blur',
+                                               knobs_dict={'label': _make_knob('')})
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.find_anchor_node', return_value=None), \
+             patch('anchors.find_anchor_by_name') as mock_find_by_name, \
+             patch('anchors.setup_link_node') as mock_setup_link_node, \
+             patch('anchors.is_anchor', return_value=False):
+
+            root_obj = MagicMock()
+            root_obj.name.return_value = 'destScript.nk'
+            mock_nuke.root.return_value = root_obj
+            mock_nuke.nodePaste.return_value = None
+            mock_nuke.selectedNodes.return_value = [dot_node]
+            mock_nuke.toNode.return_value = same_named_dest_node  # Blur1 exists in dest
+
+            from anchors import paste_anchors
+            paste_anchors()
+
+            mock_setup_link_node.assert_not_called()
             mock_find_by_name.assert_not_called()
 
 
@@ -623,6 +764,7 @@ class TestPasteHiddenSameScriptDotTypeBehavior(unittest.TestCase):
             mock_nuke.root.return_value = root_obj
             mock_nuke.nodePaste.return_value = None
             mock_nuke.selectedNodes.return_value = [dot_node]
+            mock_nuke.toNode.return_value = source_node
 
             from anchors import paste_anchors
             paste_anchors()
@@ -761,6 +903,7 @@ class TestPasteHiddenSameScriptDotTypeKnobPreservation(unittest.TestCase):
             mock_nuke.root.return_value = root_obj
             mock_nuke.nodePaste.return_value = None
             mock_nuke.selectedNodes.return_value = [dot_node]
+            mock_nuke.toNode.return_value = source_node
 
             from anchors import paste_anchors
             paste_anchors()


### PR DESCRIPTION
## Summary

- Local Dots now store `"scriptStem.nodeFullName"` (e.g. `"shotA.Blur1"`) in their FQNN knob at copy time, instead of the bare node name
- New `_find_local_node()` helper verifies the stem matches the current script before resolving — cross-script pastes return `None` and leave the dot disconnected
- All other link types are unaffected (no stem in their FQNNs, unchanged behaviour)

Closes #33

## Test plan

- [ ] `python3 -m pytest tests/ -v` — 324 tests pass
- [ ] New `TestFindLocalNode` unit tests cover stem-match, stem-mismatch, empty, no-stem, and group-nested cases
- [ ] New `test_local_dot_cross_script_false_positive_does_not_reconnect` is the key regression: a Blur1 node exists in the destination but the local dot does **not** reconnect
- [ ] Same-script paste still reconnects correctly (`test_local_dot_pasted_same_script_restores_local_label_and_color_after_setup_link_node`)
- [ ] `test_local_dot_no_stem_fqnn_does_not_reconnect` replaces the old GitHub #28 test — old-format dots (no stem) no longer reconnect; they are restamped at copy time before any paste occurs so this is purely defensive