### PR TITLE
fix: remove paste input nodes as links feature (issue #41)

### DIFF
--- a/anchors.py
+++ b/anchors.py
@@ -1,9 +1,4 @@
-"""Copy-cut-paste behaviour that re-connects hidden inputs and replaces
-input-type nodes with hidden-inputted NoOp link nodes.
-
-Configure which node classes trigger link replacement by editing LINK_SOURCE_CLASSES
-in constants.py.
-"""
+"""Copy-cut-paste behaviour that re-connects hidden inputs."""
 
 import os
 
@@ -17,7 +12,6 @@ from constants import (
     DOT_TYPE_KNOB_NAME,
     HIDDEN_INPUT_CLASSES,
     KNOB_NAME,
-    LINK_SOURCE_CLASSES,
     LOCAL_DOT_COLOR,
 )
 from link import (
@@ -37,13 +31,9 @@ def _get_script_stem():
     return os.path.splitext(os.path.basename(nuke.root().name()))[0]
 
 
-def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-class paths × same/cross-script gate
+def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: multiple node-class paths × same/cross-script gate
     """Add a hidden knob storing the original name of the node/node's input. We
     can then, when pasting, replace the node or reconnect its inputs.
-
-    Setting cut to True does not store the original name on nodes in LINK_SOURCE_CLASSES,
-    causing our paste routine to do a normal paste without replacement. This is required
-    for cuts, as the original node will have been deleted.
 
     Uses `with nuke.lastHitGroup():` so that when this is triggered from a Group
     View floating panel (where nuke.thisGroup() = root but the user's last click
@@ -83,30 +73,6 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: 3 node-cl
                     node['tile_color'].setValue(LOCAL_DOT_COLOR)
                     node[KNOB_NAME].setText(stored_fqnn)
 
-
-            # Path A — LINK_SOURCE_CLASSES file node: scan for an anchor whose input is this
-            # node and store the anchor's FQNN so paste can read the correct link class
-            # from the anchor's hidden knob. Falls back to the file node's own FQNN when
-            # no anchor points at it (legacy direct-file-node path).
-            elif node.Class() in LINK_SOURCE_CLASSES:
-                if prefs.link_classes_paste_mode == 'passthrough':
-                    # skip stamping; node copies plainly via nuke.nodeCopy() at end of function
-                    continue
-                if cut:
-                    stored_fqnn = ""
-                else:
-                    anchor_for_node = None
-                    for candidate in nuke.allNodes():
-                        if is_anchor(candidate) and candidate.input(0) is node:
-                            anchor_for_node = candidate
-                            break
-                    if anchor_for_node is not None:
-                        stored_fqnn = get_fully_qualified_node_name(anchor_for_node)
-                    else:
-                        # Legacy fallback: no anchor found, store the file node's own FQNN
-                        stored_fqnn = get_fully_qualified_node_name(node)
-                add_input_knob(node)
-                node[KNOB_NAME].setText(stored_fqnn)
 
             # Path B — hidden-input Dot (or PostageStamp/NoOp with hide_input set):
             # split on whether the upstream input is an anchor (Link Dot) or a plain node (Local Dot).
@@ -224,25 +190,7 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
                 # we haven't stored any info on this node, do nothing
                 continue
 
-            if node.Class() in LINK_SOURCE_CLASSES:
-                # Path A: file node pasted → replace with a link node.
-                # find_anchor_node() resolves the stored FQNN; None means cross-script or
-                # deleted.
-                input_node = find_anchor_node(node)
-                if not input_node:
-                    # Cross-script (or deleted) case: find_anchor_node() returned None.
-                    # File nodes are left disconnected as placeholders.
-                    continue
-                nukescripts.clear_selection_recursive()
-                node["selected"].setValue(True)
-                link_node = nuke.createNode(get_link_class_for_source(input_node))
-                setup_link_node(input_node, link_node)
-                link_node.setXYpos(node.xpos(), node.ypos())
-                final_selection.remove(node)
-                final_selection.append(link_node)
-                nuke.delete(node)
-
-            elif (is_anchor(node)
+            if (is_anchor(node)
                   and DOT_TYPE_KNOB_NAME in node.knobs()
                   and node[DOT_TYPE_KNOB_NAME].getValue() == 'link'):
                 # Path D (Issue #37): pasted node is an anchor that was stamped at copy

--- a/colors.py
+++ b/colors.py
@@ -653,7 +653,6 @@ else:
             import prefs as prefs_module
             # Seed local working copies — never mutate prefs module vars until accept
             self._local_plugin_enabled = prefs_module.plugin_enabled
-            self._local_link_mode = prefs_module.link_classes_paste_mode
             self._local_custom_colors = list(prefs_module.custom_colors)
             # Snapshot of custom colors at open time so _on_accept can detect changes
             # and recolor any anchor nodes using the old color values.
@@ -682,11 +681,6 @@ else:
             self._plugin_checkbox = QtWidgets.QCheckBox("Enable anchors plugin")
             self._plugin_checkbox.setChecked(self._local_plugin_enabled)
             outer_layout.addWidget(self._plugin_checkbox)
-
-            # Checkbox: link classes paste mode
-            self._link_mode_checkbox = QtWidgets.QCheckBox("Input nodes paste as links")
-            self._link_mode_checkbox.setChecked(self._local_link_mode == "create_link")
-            outer_layout.addWidget(self._link_mode_checkbox)
 
             # ---- Anchor Naming section ----
             naming_section_label = QtWidgets.QLabel("Anchor Naming")
@@ -1047,7 +1041,7 @@ else:
             if not self._swatch_buttons:
                 return
             # Chain from the last focusable checkbox down to the first swatch button
-            QtWidgets.QWidget.setTabOrder(self._link_mode_checkbox, self._swatch_buttons[0])
+            QtWidgets.QWidget.setTabOrder(self._plugin_checkbox, self._swatch_buttons[0])
             # Chain each swatch button to the next one
             for swatch_index in range(len(self._swatch_buttons) - 1):
                 QtWidgets.QWidget.setTabOrder(
@@ -1177,14 +1171,10 @@ else:
         def _on_accept(self):
             """Flush local working copies to prefs module, persist, and close."""
             import prefs as prefs_module
-            # Read current checkbox states into local vars (user may have changed them)
+            # Read current checkbox state into local var (user may have changed it)
             self._local_plugin_enabled = self._plugin_checkbox.isChecked()
-            self._local_link_mode = (
-                "create_link" if self._link_mode_checkbox.isChecked() else "passthrough"
-            )
-            # Flush plugin_enabled and link mode to prefs module immediately
+            # Flush plugin_enabled to prefs module immediately
             prefs_module.plugin_enabled = self._local_plugin_enabled
-            prefs_module.link_classes_paste_mode = self._local_link_mode
             # Apply plugin_enabled live (menu enable/disable without restart).
             # set_anchors_menu_enabled is stored on the prefs module by menu.py at startup,
             # avoiding any import conflict with Nuke's built-in 'menu' module.

--- a/constants.py
+++ b/constants.py
@@ -9,11 +9,6 @@ KNOB_NAME = 'copy_hidden_input_node'
 # FROZEN: value stored in .nk files — do not rename
 LINK_RECONNECT_KNOB_NAME = "reconnect_link"
 HIDDEN_INPUT_CLASSES = ['PostageStamp', 'Dot', 'NoOp']
-LINK_SOURCE_CLASSES = frozenset({
-    "Read", "DeepRead", "ReadGeo",
-    "Camera", "Camera2", "Camera3", "Camera4",
-    "GeoImport",
-})
 
 ANCHOR_PREFIX = 'Anchor_'
 # FROZEN: value stored in .nk files — do not rename

--- a/prefs.py
+++ b/prefs.py
@@ -5,7 +5,6 @@ Writes via explicit save() call only — called by Phase 7 PrefsDialog on accept
 
 Module-level variables (read these directly after import):
     plugin_enabled          bool  — True if the plugin is active
-    link_classes_paste_mode str   — 'create_link' or 'passthrough'
     custom_colors           list  — list of 0xRRGGBBAA color ints
 """
 
@@ -18,7 +17,6 @@ from constants import OLD_PREFS_PATH, PREFS_PATH, USER_PALETTE_PATH
 # Defaults — overwritten by _load() at module import time
 # ---------------------------------------------------------------------------
 plugin_enabled = True
-link_classes_paste_mode = "passthrough"
 custom_colors = []
 naming_regex = ""
 naming_template = ""
@@ -57,7 +55,7 @@ def _migrate_from_old_prefs_file():
     Called only when anchors_prefs.json does not exist but paste_hidden_prefs.json does.
     Never modifies the old file. Silent no-op if old file is absent or corrupt.
     """
-    global plugin_enabled, link_classes_paste_mode, custom_colors
+    global plugin_enabled, custom_colors
     if not os.path.exists(OLD_PREFS_PATH):
         return
     try:
@@ -75,7 +73,7 @@ def _load():
     back to defaults. Per-key type validation ensures corrupt individual values
     do not poison valid ones.
     """
-    global plugin_enabled, link_classes_paste_mode, custom_colors, \
+    global plugin_enabled, custom_colors, \
            naming_regex, naming_template, naming_demo_filename, \
            site_config_override, last_publish_path, \
            _user_naming_regex, _user_naming_template, \
@@ -94,8 +92,6 @@ def _load():
             data = json.load(file_handle)
         if isinstance(data.get('plugin_enabled'), bool):
             plugin_enabled = data['plugin_enabled']
-        if data.get('link_classes_paste_mode') in ('create_link', 'passthrough'):
-            link_classes_paste_mode = data['link_classes_paste_mode']
         if isinstance(data.get('custom_colors'), list):
             custom_colors = [int(color_value) for color_value in data['custom_colors']
                              if isinstance(color_value, (int, float))]
@@ -169,7 +165,6 @@ def save():
         json.dump(
             {
                 'plugin_enabled': plugin_enabled,
-                'link_classes_paste_mode': link_classes_paste_mode,
                 'custom_colors': custom_colors,
                 'naming_regex': _user_naming_regex,
                 'naming_template': _user_naming_template,

--- a/tests/test_copy_anchor_as_link.py
+++ b/tests/test_copy_anchor_as_link.py
@@ -98,7 +98,6 @@ def _patch_copy(mock_nuke, selected_nodes, prefs_mock):
     mock_nuke.nodeCopy.return_value = None
     mock_nuke.allNodes.return_value = []
     prefs_mock.plugin_enabled = True
-    prefs_mock.link_classes_paste_mode = 'replace'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cross_script_paste.py
+++ b/tests/test_cross_script_paste.py
@@ -2,10 +2,8 @@
 
 Covers:
 - _extract_display_name_from_fqnn() helper
-- paste_anchors() Path A/C cross-script name-based reconnect for NoOp anchors (XSCRIPT-01)
+- paste_anchors() Path C cross-script name-based reconnect for NoOp anchors (XSCRIPT-01)
 - paste_anchors() Path B Dot cross-script disconnection (XSCRIPT-02 / PASTE-04)
-- LINK_SOURCE_CLASSES frozenset membership
-- ANCHOR_LINK_CLASS_KNOB_NAME removed from constants
 """
 
 import sys
@@ -13,33 +11,6 @@ import types
 import unittest
 from unittest.mock import MagicMock, patch, call
 
-
-
-# ---------------------------------------------------------------------------
-# Tests for LINK_SOURCE_CLASSES and removed ANCHOR_LINK_CLASS_KNOB_NAME
-# ---------------------------------------------------------------------------
-
-class TestConstantsCleanup(unittest.TestCase):
-
-    def test_link_source_classes_contains_all_eight_expected_class_names(self):
-        from constants import LINK_SOURCE_CLASSES
-        expected_classes = {
-            "Read", "DeepRead", "ReadGeo",
-            "Camera", "Camera2", "Camera3", "Camera4",
-            "GeoImport",
-        }
-        self.assertEqual(LINK_SOURCE_CLASSES, expected_classes)
-
-    def test_link_source_classes_is_a_frozenset(self):
-        from constants import LINK_SOURCE_CLASSES
-        self.assertIsInstance(LINK_SOURCE_CLASSES, frozenset)
-
-    def test_anchor_link_class_knob_name_not_importable_from_constants(self):
-        import constants
-        self.assertFalse(
-            hasattr(constants, 'ANCHOR_LINK_CLASS_KNOB_NAME'),
-            "ANCHOR_LINK_CLASS_KNOB_NAME should have been removed from constants.py",
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -356,97 +327,6 @@ class TestBugRegressions(unittest.TestCase):
 
         mock_nuke.createNode.assert_not_called()
         mock_nuke.delete.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Regression test for GitHub issue #9 — only every other Read node replaced on paste
-# ---------------------------------------------------------------------------
-
-class TestMultipleReadNodePaste(unittest.TestCase):
-    """Regression tests for GitHub issue #9.
-
-    When multiple Read nodes (or other LINK_SOURCE_CLASSES nodes) are pasted at
-    once, ALL of them must be replaced by link nodes — not just every other one.
-
-    The bug was caused by iterating `for node in selected_nodes:` while calling
-    `selected_nodes.remove(node)` inside the loop, which shifted list indices and
-    caused the loop to skip every other element.
-    """
-
-    def _make_read_node(self, name, stored_fqnn, xpos=0, ypos=0):
-        """Return a stub Read node with KNOB_NAME set, simulating a copied read node."""
-        import nuke as _nuke
-        from constants import KNOB_NAME
-        return _nuke.StubNode(
-            name=name,
-            node_class='Read',
-            xpos=xpos,
-            ypos=ypos,
-            knobs_dict={
-                KNOB_NAME: _nuke.StubKnob(stored_fqnn),
-                'selected': _nuke.StubKnob(False),
-            },
-        )
-
-    def test_all_three_read_nodes_replaced_when_pasted_together(self):
-        """All three Read nodes must be replaced by link nodes in a single paste.
-
-        Before the fix, only nodes at even indices (0, 2) were processed — the
-        node at index 1 was skipped because remove() shifted the list mid-iteration.
-        """
-        import nuke as _nuke
-        from constants import KNOB_NAME
-
-        script_stem = 'myScript'
-        anchor_node = _nuke.StubNode(name='Anchor_Footage', node_class='NoOp')
-
-        read_nodes = [
-            self._make_read_node('Read1', f'{script_stem}.Anchor_Footage', xpos=0, ypos=0),
-            self._make_read_node('Read2', f'{script_stem}.Anchor_Footage', xpos=100, ypos=0),
-            self._make_read_node('Read3', f'{script_stem}.Anchor_Footage', xpos=200, ypos=0),
-        ]
-
-        created_link_nodes = []
-
-        def fake_create_node(node_class):
-            link_node = _nuke.StubNode(
-                name=f'NoOp_link_{len(created_link_nodes)}',
-                node_class=node_class,
-                knobs_dict={'selected': _nuke.StubKnob(False)},
-            )
-            created_link_nodes.append(link_node)
-            return link_node
-
-        deleted_nodes = []
-
-        with patch('anchors.nuke') as mock_nuke, \
-             patch('anchors.nukescripts') as mock_nukescripts, \
-             patch('anchors.find_anchor_node', return_value=anchor_node), \
-             patch('anchors.is_anchor', return_value=False), \
-             patch('anchors.get_link_class_for_source', return_value='NoOp'), \
-             patch('anchors.setup_link_node'):
-
-            mock_nuke.nodePaste.return_value = None
-            mock_nuke.selectedNodes.return_value = read_nodes
-            mock_nuke.createNode.side_effect = fake_create_node
-            mock_nuke.delete.side_effect = deleted_nodes.append
-            mock_nuke.root.return_value.name.return_value = f'{script_stem}.nk'
-
-            from anchors import paste_anchors
-            paste_anchors()
-
-        self.assertEqual(
-            len(deleted_nodes),
-            3,
-            f"Expected all 3 Read nodes to be deleted (replaced by link nodes) "
-            f"but only {len(deleted_nodes)} were deleted — "
-            f"every-other-node skip bug (GitHub #9) is present",
-        )
-        self.assertEqual(
-            len(created_link_nodes),
-            3,
-            f"Expected 3 link nodes to be created but got {len(created_link_nodes)}",
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -94,11 +94,8 @@ class TestPrefsFirstRunCreatesFile(unittest.TestCase):
                 with open(temp_prefs_path) as file_handle:
                     data = json.load(file_handle)
                 self.assertIn('plugin_enabled', data, "prefs file must contain plugin_enabled key")
-                self.assertIn('link_classes_paste_mode', data,
-                              "prefs file must contain link_classes_paste_mode key")
                 self.assertIn('custom_colors', data, "prefs file must contain custom_colors key")
                 self.assertEqual(data['plugin_enabled'], True)
-                self.assertEqual(data['link_classes_paste_mode'], 'passthrough')
                 self.assertEqual(data['custom_colors'], [])
             finally:
                 constants.PREFS_PATH = original_prefs_path
@@ -153,7 +150,6 @@ class TestPrefsFirstRunCreatesFile(unittest.TestCase):
             # Pre-create the prefs file with non-default values
             existing_data = {
                 'plugin_enabled': False,
-                'link_classes_paste_mode': 'passthrough',
                 'custom_colors': [0xdeadbeef],
             }
             with open(temp_prefs_path, 'w') as file_handle:
@@ -174,7 +170,6 @@ class TestPrefsFirstRunCreatesFile(unittest.TestCase):
                     data = json.load(file_handle)
                 self.assertEqual(data['plugin_enabled'], False,
                                  "existing prefs should not be overwritten on load")
-                self.assertEqual(data['link_classes_paste_mode'], 'passthrough')
             finally:
                 constants.PREFS_PATH = original_prefs_path
                 constants.USER_PALETTE_PATH = original_palette_path
@@ -253,7 +248,6 @@ class TestNamingPrefsRoundTrip(unittest.TestCase):
             # Write a prefs file with naming fields pre-populated
             prefs_data = {
                 'plugin_enabled': True,
-                'link_classes_paste_mode': 'create_link',
                 'custom_colors': [],
                 'naming_regex': r'(?P<name>\w+)',
                 'naming_template': '{name}_anchor',
@@ -290,7 +284,6 @@ class TestNamingPrefsRoundTrip(unittest.TestCase):
             # Write a prefs file with invalid types for naming fields
             prefs_data = {
                 'plugin_enabled': True,
-                'link_classes_paste_mode': 'create_link',
                 'custom_colors': [],
                 'naming_regex': 42,          # int — not a string
                 'naming_template': ['list'], # list — not a string
@@ -392,7 +385,6 @@ class TestNamingDemoFilenameRoundTrip(unittest.TestCase):
 
             prefs_data = {
                 'plugin_enabled': True,
-                'link_classes_paste_mode': 'create_link',
                 'custom_colors': [],
                 'naming_regex': '',
                 'naming_template': '',
@@ -449,8 +441,8 @@ class TestPublish(unittest.TestCase):
         """publish(path) creates a sparse site config JSON containing ONLY naming fields.
 
         Phase 16: publish() must write only naming_regex, naming_template,
-        naming_demo_filename. Non-naming fields (plugin_enabled,
-        link_classes_paste_mode, custom_colors) must be absent.
+        naming_demo_filename. Non-naming fields (plugin_enabled, custom_colors)
+        must be absent.
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             default_prefs_path = os.path.join(temp_dir, 'anchors_prefs.json')
@@ -481,10 +473,6 @@ class TestPublish(unittest.TestCase):
             self.assertNotIn(
                 'plugin_enabled', data,
                 "publish() must NOT write plugin_enabled — site config must be naming-only",
-            )
-            self.assertNotIn(
-                'link_classes_paste_mode', data,
-                "publish() must NOT write link_classes_paste_mode — site config must be naming-only",
             )
             self.assertNotIn(
                 'custom_colors', data,
@@ -592,7 +580,6 @@ class TestSiteConfigLoading(unittest.TestCase):
         """Write a minimal user prefs JSON file with optional field overrides."""
         user_prefs_data = {
             'plugin_enabled': True,
-            'link_classes_paste_mode': 'create_link',
             'custom_colors': [],
             'naming_regex': 'user_regex',
             'naming_template': 'user_template',
@@ -855,7 +842,6 @@ class TestLastPublishPath(unittest.TestCase):
 
             prefs_data = {
                 'plugin_enabled': True,
-                'link_classes_paste_mode': 'create_link',
                 'custom_colors': [],
                 'naming_regex': '',
                 'naming_template': '',


### PR DESCRIPTION
## Summary

- Removes the feature that automatically replaced Read/DeepRead/Camera/etc. nodes with link nodes on paste, following user feedback that it was unwanted
- Deletes `LINK_SOURCE_CLASSES` frozenset from `constants.py` and all code that referenced it in `anchors.py` (Path A copy and paste blocks), `prefs.py` (`link_classes_paste_mode` preference), and `colors.py` (the "Input nodes paste as links" checkbox in PrefsDialog)
- Removes all associated tests (`TestConstantsCleanup`, `TestMultipleReadNodePaste`) and cleans up all `link_classes_paste_mode` fixture references across the test suite

Closes #41

## Test plan

- [x] Run full test suite: `python3 -m pytest tests/ -x -q` — 322 tests pass
- [x] Verify `LINK_SOURCE_CLASSES` is gone from `constants.py`
- [x] Verify `link_classes_paste_mode` is gone from `prefs.py`, `colors.py`, and all test fixtures
- [x] Verify no other anchor/link logic was touched