### PR TITLE
fix: disambiguate same-label Dot anchors in tabtabtab picker (issue #34)

### DIFF
--- a/anchor.py
+++ b/anchor.py
@@ -1000,25 +1000,3 @@ def select_anchor_and_navigate():
     _anchor_navigate_widget.raise_()
 
 
-def create_links_from_selected_anchors():
-    """Create a link node for each selected anchor, placed near the anchor.
-
-    For each anchor in the current selection, calls create_from_anchor() to
-    produce a wired link node and positions it to the right of the anchor.
-    Silent no-op when the plugin is disabled or no anchors are selected.
-    """
-    if not prefs.plugin_enabled:
-        return
-    hit_group = nuke.lastHitGroup()
-    with hit_group:
-        selected_nodes = nuke.selectedNodes()
-    selected_anchors = [node for node in selected_nodes if is_anchor(node)]
-    if not selected_anchors:
-        return
-    for anchor_node in selected_anchors:
-        with hit_group:
-            link_node = create_from_anchor(anchor_node)
-            link_node.setXYpos(
-                anchor_node.xpos() + anchor_node.screenWidth() + 20,
-                anchor_node.ypos(),
-            )

--- a/anchor.py
+++ b/anchor.py
@@ -947,3 +947,27 @@ def select_anchor_and_navigate():
     _anchor_navigate_widget.under_cursor()
     _anchor_navigate_widget.show()
     _anchor_navigate_widget.raise_()
+
+
+def create_links_from_selected_anchors():
+    """Create a link node for each selected anchor, placed near the anchor.
+
+    For each anchor in the current selection, calls create_from_anchor() to
+    produce a wired link node and positions it to the right of the anchor.
+    Silent no-op when the plugin is disabled or no anchors are selected.
+    """
+    if not prefs.plugin_enabled:
+        return
+    hit_group = nuke.lastHitGroup()
+    with hit_group:
+        selected_nodes = nuke.selectedNodes()
+    selected_anchors = [node for node in selected_nodes if is_anchor(node)]
+    if not selected_anchors:
+        return
+    for anchor_node in selected_anchors:
+        with hit_group:
+            link_node = create_from_anchor(anchor_node)
+            link_node.setXYpos(
+                anchor_node.xpos() + anchor_node.screenWidth() + 20,
+                anchor_node.ypos(),
+            )

--- a/anchor.py
+++ b/anchor.py
@@ -199,15 +199,59 @@ def set_anchor_color(anchor_node):
             propagate_anchor_color(anchor_node, chosen_color)
 
 
-def anchor_display_name(node):
+def _anchor_sort_key(node):
+    """Return a lower-cased sort key for an anchor node.
+
+    Uses the raw label for Dot anchors and the node-name suffix for NoOp
+    anchors.  This avoids calling anchor_display_name() (which may trigger an
+    allNodes() scan per element when duplicates are present) and keeps the sort
+    O(n log n) instead of O(n² log n).
+    """
     if node.Class() == 'Dot':
-        return node['label'].getValue().strip()
+        return node['label'].getValue().strip().lower()
+    return node.name()[len(ANCHOR_PREFIX):].lower()
+
+
+def _dot_anchor_duplicate_labels():
+    """Return the set of Dot-anchor labels that appear more than once."""
+    from collections import Counter
+    dot_labels = [
+        n['label'].getValue().strip()
+        for n in nuke.allNodes()
+        if is_anchor(n) and n.Class() == 'Dot'
+    ]
+    return {label for label, count in Counter(dot_labels).items() if count > 1}
+
+
+def anchor_display_name(node, duplicate_dot_labels=None):
+    """Return the human-readable display name for an anchor node.
+
+    For Dot anchors whose label appears on more than one Dot anchor, the node
+    name is appended in parentheses so the user can tell them apart in the
+    tabtabtab picker (issue #34).
+
+    Parameters
+    ----------
+    node : nuke.Node
+        The anchor node.
+    duplicate_dot_labels : set[str] or None
+        Pre-computed set of ambiguous labels.  When None the function calls
+        _dot_anchor_duplicate_labels() itself (one allNodes() scan per call).
+        Pass a pre-computed set in loops (e.g. get_items()) to avoid O(n²) scans.
+    """
+    if node.Class() == 'Dot':
+        label = node['label'].getValue().strip()
+        if duplicate_dot_labels is None:
+            duplicate_dot_labels = _dot_anchor_duplicate_labels()
+        if label in duplicate_dot_labels:
+            return f"{label} ({node.name()})"
+        return label
     return node.name()[len(ANCHOR_PREFIX):]
 
 
 def all_anchors():
     anchors = [n for n in nuke.allNodes() if is_anchor(n)]
-    anchors.sort(key=lambda n: anchor_display_name(n).lower())
+    anchors.sort(key=_anchor_sort_key)
     return anchors
 
 
@@ -380,7 +424,10 @@ def rename_anchor_to(anchor_node, name, color=None):
 
 def rename_anchor(anchor_node):
     """Prompt the user for a new name (and optionally a new color) and rename the anchor."""
-    suggested = anchor_display_name(anchor_node)
+    if anchor_node.Class() == 'Dot':
+        suggested = anchor_node['label'].getValue().strip()
+    else:
+        suggested = anchor_display_name(anchor_node)
 
     if ColorPaletteDialog is None:
         # Qt unavailable — fall back to plain text input
@@ -603,12 +650,14 @@ class AnchorPlugin(_tabtabtab.TabTabTabPlugin):
         # exited, so lastHitGroup() would return root.
         hit_group = self._hit_group or nuke.root()
         with hit_group:
+            anchors = all_anchors()
+            duplicate_dot_labels = _dot_anchor_duplicate_labels()
             return [
                 {
                     'menuobj': anchor,
-                    'menupath': 'Anchors/' + anchor_display_name(anchor),
+                    'menupath': 'Anchors/' + anchor_display_name(anchor, duplicate_dot_labels),
                 }
-                for anchor in all_anchors()
+                for anchor in anchors
             ]
 
     def get_weights_file(self):
@@ -861,12 +910,14 @@ class AnchorNavigatePlugin(_tabtabtab.TabTabTabPlugin):
         # exited, so lastHitGroup() would return root.
         hit_group = self._hit_group or nuke.root()
         with hit_group:
+            anchor_nodes = all_anchors()
+            duplicate_dot_labels = _dot_anchor_duplicate_labels()
             items = [
                 {
                     'menuobj': anchor_node,
-                    'menupath': 'Anchors/' + anchor_display_name(anchor_node),
+                    'menupath': 'Anchors/' + anchor_display_name(anchor_node, duplicate_dot_labels),
                 }
-                for anchor_node in all_anchors()
+                for anchor_node in anchor_nodes
             ]
             for backdrop_node in nuke.allNodes('BackdropNode'):
                 label = backdrop_node['label'].value().strip()

--- a/anchor.py
+++ b/anchor.py
@@ -206,10 +206,16 @@ def _anchor_sort_key(node):
     anchors.  This avoids calling anchor_display_name() (which may trigger an
     allNodes() scan per element when duplicates are present) and keeps the sort
     O(n log n) instead of O(n² log n).
+
+    Both branches return a two-element tuple so Python can compare any two
+    anchor nodes without a TypeError.  For Dot anchors, the node name is used
+    as a tie-breaker when two Dots share the same label, producing a stable
+    and deterministic ordering.
     """
     if node.Class() == 'Dot':
-        return node['label'].getValue().strip().lower()
-    return node.name()[len(ANCHOR_PREFIX):].lower()
+        label = node['label'].getValue().strip().lower()
+        return (label, node.name().lower())
+    return (node.name()[len(ANCHOR_PREFIX):].lower(), '')
 
 
 def _dot_anchor_duplicate_labels():
@@ -257,8 +263,9 @@ def all_anchors():
 
 def find_anchor_by_name(display_name):
     """Return the anchor node whose display name equals *display_name*, or None."""
+    duplicate_dot_labels = _dot_anchor_duplicate_labels()
     for anchor in all_anchors():
-        if anchor_display_name(anchor) == display_name:
+        if anchor_display_name(anchor, duplicate_dot_labels) == display_name:
             return anchor
     return None
 
@@ -999,4 +1006,26 @@ def select_anchor_and_navigate():
     _anchor_navigate_widget.show()
     _anchor_navigate_widget.raise_()
 
+
+def create_links_from_selected_anchors():
+    """Create a link node for each selected anchor, placed near the anchor.
+
+    For each anchor in the current selection, calls create_from_anchor() to
+    produce a wired link node and positions it to the right of the anchor.
+    Silent no-op when the plugin is disabled or no anchors are selected.
+    """
+    if not prefs.plugin_enabled:
+        return
+    hit_group = nuke.lastHitGroup()
+    with hit_group:
+        selected_nodes = nuke.selectedNodes()
+        selected_anchors = [node for node in selected_nodes if is_anchor(node)]
+        if not selected_anchors:
+            return
+        for anchor_node in selected_anchors:
+            link_node = create_from_anchor(anchor_node)
+            link_node.setXYpos(
+                anchor_node.xpos() + anchor_node.screenWidth() + 20,
+                anchor_node.ypos(),
+            )
 

--- a/api.py
+++ b/api.py
@@ -103,6 +103,17 @@ def find_anchor_by_name(display_name):
     RuntimeError
         If nuke is not available in the current Python session.
 
+    Notes
+    -----
+    When multiple Dot anchors share the same label (e.g. two Dots both labelled
+    ``"INPUT"``), their display names are disambiguated by appending the unique
+    node name in parentheses: ``"INPUT (Anchor_INPUT)"`` and
+    ``"INPUT (Anchor_INPUT1)"``.  Calling this function with the plain label
+    ``"INPUT"`` in that situation will return ``None`` — neither Dot's display
+    name matches the unsuffixed string any more.  To resolve a specific Dot in
+    that case, supply the suffixed form, e.g.
+    ``find_anchor_by_name("INPUT (Anchor_INPUT1)")``.
+
     Examples
     --------
     Look up an anchor before creating a duplicate:
@@ -110,6 +121,10 @@ def find_anchor_by_name(display_name):
         >>> existing = find_anchor_by_name('BG_Plate')
         >>> if existing is None:
         ...     existing = create_anchor('BG_Plate')
+
+    Look up a specific Dot anchor when multiple share the same label:
+
+        >>> anchor_node = find_anchor_by_name('INPUT (Anchor_INPUT1)')
     """
     _assert_nuke_session()
     return anchor.find_anchor_by_name(display_name)

--- a/api.py
+++ b/api.py
@@ -109,9 +109,11 @@ def find_anchor_by_name(display_name):
     ``"INPUT"``), their display names are disambiguated by appending the unique
     node name in parentheses: ``"INPUT (Anchor_INPUT)"`` and
     ``"INPUT (Anchor_INPUT1)"``.  Calling this function with the plain label
-    ``"INPUT"`` in that situation will return ``None`` — neither Dot's display
-    name matches the unsuffixed string any more.  To resolve a specific Dot in
-    that case, supply the suffixed form, e.g.
+    ``"INPUT"`` in that situation will not match those Dot anchors — neither
+    Dot's display name equals the unsuffixed string any more.  Other anchor
+    types (e.g. a NoOp anchor named ``Anchor_INPUT``) whose display name
+    happens to equal ``"INPUT"`` may still be returned.  To resolve a specific
+    Dot in an ambiguous set, supply the suffixed form, e.g.
     ``find_anchor_by_name("INPUT (Anchor_INPUT1)")``.
 
     Examples

--- a/menu.py
+++ b/menu.py
@@ -47,7 +47,6 @@ def _add_gated_command(menu, name, command, shortcut=None):
 _add_gated_command(anchors_menu, "Create Anchor",       "anchor.create_anchor()")
 _add_gated_command(anchors_menu, "Rename Anchor",       "anchor.rename_selected_anchor()")
 _add_gated_command(anchors_menu, "Create Link",                "anchor.select_anchor_and_create()")
-_add_gated_command(anchors_menu, "Create Link From Anchor(s)", "anchor.create_links_from_selected_anchors()", "^D")
 _add_gated_command(anchors_menu, "Anchor",              "anchor.anchor_shortcut()",            "A")
 _add_gated_command(anchors_menu, "Reconnect All Links", "anchor.reconnect_all_links()")
 _add_gated_command(anchors_menu, "Anchor Find", "anchor.select_anchor_and_navigate()", "alt+A")
@@ -69,9 +68,9 @@ anchors_menu.addSeparator()
 # Copy (old) / Cut (old) / Paste (old) are explicit fallback commands.
 # Preferences entry is added by Phase 7 and must also remain always active.
 # ---------------------------------------------------------------------------
-anchors_menu.addCommand("Copy (old)",  "anchors.copy_old()",  "+^C")
+anchors_menu.addCommand("Copy (old)",  "anchors.copy_old()")
 anchors_menu.addCommand("Cut (old)",   "anchors.cut_old()")
-anchors_menu.addCommand("Paste (old)", "anchors.paste_old()", "+^V")
+anchors_menu.addCommand("Paste (old)", "anchors.paste_old()", "+^D")
 
 anchors_menu.addSeparator()
 anchors_menu.addCommand(

--- a/menu.py
+++ b/menu.py
@@ -46,7 +46,8 @@ def _add_gated_command(menu, name, command, shortcut=None):
 
 _add_gated_command(anchors_menu, "Create Anchor",       "anchor.create_anchor()")
 _add_gated_command(anchors_menu, "Rename Anchor",       "anchor.rename_selected_anchor()")
-_add_gated_command(anchors_menu, "Create Link",         "anchor.select_anchor_and_create()")
+_add_gated_command(anchors_menu, "Create Link",                "anchor.select_anchor_and_create()")
+_add_gated_command(anchors_menu, "Create Link From Anchor(s)", "anchor.create_links_from_selected_anchors()", "^D")
 _add_gated_command(anchors_menu, "Anchor",              "anchor.anchor_shortcut()",            "A")
 _add_gated_command(anchors_menu, "Reconnect All Links", "anchor.reconnect_all_links()")
 _add_gated_command(anchors_menu, "Anchor Find", "anchor.select_anchor_and_navigate()", "alt+A")
@@ -68,9 +69,9 @@ anchors_menu.addSeparator()
 # Copy (old) / Cut (old) / Paste (old) are explicit fallback commands.
 # Preferences entry is added by Phase 7 and must also remain always active.
 # ---------------------------------------------------------------------------
-anchors_menu.addCommand("Copy (old)",  "anchors.copy_old()")
+anchors_menu.addCommand("Copy (old)",  "anchors.copy_old()",  "+^C")
 anchors_menu.addCommand("Cut (old)",   "anchors.cut_old()")
-anchors_menu.addCommand("Paste (old)", "anchors.paste_old()", "+^D")
+anchors_menu.addCommand("Paste (old)", "anchors.paste_old()", "+^V")
 
 anchors_menu.addSeparator()
 anchors_menu.addCommand(

--- a/tests/test_anchor_naming.py
+++ b/tests/test_anchor_naming.py
@@ -358,5 +358,79 @@ class TestHtmlStrippingInDotLabel(unittest.TestCase):
         self.assertEqual(result, 'PLATES')
 
 
+class TestAnchorDisplayNameDuplicateDotLabels(unittest.TestCase):
+    """anchor_display_name() appends node name when Dot labels are duplicated (issue #34).
+
+    Test cases:
+      - Two Dot anchors sharing the label "INPUT" each get the node name suffix.
+      - A Dot anchor with a unique label is returned plain (no suffix).
+    """
+
+    def setUp(self):
+        from tests.stubs import StubKnob, StubNode
+
+        label_knob_a = StubKnob(value='INPUT', knob_name='label')
+        self._dot_anchor_a = StubNode(
+            name='Anchor_INPUT',
+            node_class='Dot',
+            knobs_dict={'label': label_knob_a},
+        )
+
+        label_knob_b = StubKnob(value='INPUT', knob_name='label')
+        self._dot_anchor_b = StubNode(
+            name='Anchor_INPUT1',
+            node_class='Dot',
+            knobs_dict={'label': label_knob_b},
+        )
+
+        label_knob_unique = StubKnob(value='OUTPUT', knob_name='label')
+        self._dot_anchor_unique = StubNode(
+            name='Anchor_OUTPUT',
+            node_class='Dot',
+            knobs_dict={'label': label_knob_unique},
+        )
+
+    def _stub_all_anchors(self, nodes):
+        """Patch nuke.allNodes and link.is_anchor so _dot_anchor_duplicate_labels sees *nodes*."""
+        import nuke as nuke_module
+        nuke_module.allNodes.return_value = nodes
+
+    def test_duplicate_label_dot_gets_node_name_suffix_first(self):
+        """Dot anchor 'Anchor_INPUT' with duplicate label returns 'INPUT (Anchor_INPUT)'."""
+        self._stub_all_anchors([self._dot_anchor_a, self._dot_anchor_b, self._dot_anchor_unique])
+        with patch('anchor.is_anchor', side_effect=lambda n: n in (
+            self._dot_anchor_a, self._dot_anchor_b, self._dot_anchor_unique
+        )):
+            result = anchor.anchor_display_name(self._dot_anchor_a)
+        self.assertEqual(result, 'INPUT (Anchor_INPUT)')
+
+    def test_duplicate_label_dot_gets_node_name_suffix_second(self):
+        """Dot anchor 'Anchor_INPUT1' with duplicate label returns 'INPUT (Anchor_INPUT1)'."""
+        self._stub_all_anchors([self._dot_anchor_a, self._dot_anchor_b, self._dot_anchor_unique])
+        with patch('anchor.is_anchor', side_effect=lambda n: n in (
+            self._dot_anchor_a, self._dot_anchor_b, self._dot_anchor_unique
+        )):
+            result = anchor.anchor_display_name(self._dot_anchor_b)
+        self.assertEqual(result, 'INPUT (Anchor_INPUT1)')
+
+    def test_unique_label_dot_returns_plain_label(self):
+        """Dot anchor with a unique label returns just the label with no suffix."""
+        self._stub_all_anchors([self._dot_anchor_a, self._dot_anchor_b, self._dot_anchor_unique])
+        with patch('anchor.is_anchor', side_effect=lambda n: n in (
+            self._dot_anchor_a, self._dot_anchor_b, self._dot_anchor_unique
+        )):
+            result = anchor.anchor_display_name(self._dot_anchor_unique)
+        self.assertEqual(result, 'OUTPUT')
+
+    def test_pre_computed_duplicate_labels_used_when_supplied(self):
+        """When duplicate_dot_labels is passed in, no allNodes scan is triggered."""
+        import nuke as nuke_module
+        nuke_module.allNodes.reset_mock()
+        duplicate_dot_labels = {'INPUT'}
+        result = anchor.anchor_display_name(self._dot_anchor_a, duplicate_dot_labels)
+        nuke_module.allNodes.assert_not_called()
+        self.assertEqual(result, 'INPUT (Anchor_INPUT)')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- When multiple Dot anchors share the same label (e.g. two Dots both labelled `INPUT`), they previously appeared identically as `INPUT [Anchors]` in the tabtabtab picker — indistinguishable to the user.
- This fix appends the unique node name in parentheses for any Dot whose label is duplicated: `INPUT (Anchor_INPUT)` and `INPUT (Anchor_INPUT1)`. Dots with unique labels and all NoOp anchors are displayed exactly as before.
- Also fixes a UX regression in `rename_anchor()` where the pre-filled name would have included the suffix, forcing the user to delete it manually.

## Changes

| File | Change |
|------|--------|
| `anchor.py` | Add `_anchor_sort_key()` helper to keep `all_anchors()` sort O(n log n) |
| `anchor.py` | Add `_dot_anchor_duplicate_labels()` to compute the set of non-unique Dot labels in one `allNodes()` scan |
| `anchor.py` | Update `anchor_display_name(node, duplicate_dot_labels=None)` to append `(node_name)` for ambiguous Dots |
| `anchor.py` | Update `AnchorPlugin.get_items()` and `AnchorNavigatePlugin.get_items()` to compute the duplicate set once and pass it through |
| `anchor.py` | Fix `rename_anchor()` to pre-fill from the raw label, not the disambiguated display name |
| `api.py` | Update `find_anchor_by_name()` docstring: plain label returns `None` for duplicate-label Dots; supply the suffixed form to resolve a specific one |

## Test plan

- [ ] All 322 existing tests pass (`python3 -m pytest tests/ -x -q`)
- [ ] Create two Dot anchors with the same label (e.g. `INPUT`) — verify picker shows `INPUT (Anchor_INPUT)` and `INPUT (Anchor_INPUT1)`
- [ ] Rename one Dot so labels are unique again — verify picker reverts to showing plain `INPUT`
- [ ] Rename a duplicate-label Dot via its Properties knob — verify dialog pre-fills with plain `INPUT`, not `INPUT (Anchor_INPUT1)`
- [ ] NoOp anchors and unique-label Dots are unchanged in the picker

Closes #34