### PR TITLE
fix: guard paste code paths against intermittent crashes (issue #38)

### DIFF
--- a/anchors.py
+++ b/anchors.py
@@ -28,6 +28,10 @@ from link import (
 def _get_script_stem():
     # os.path.splitext handles multi-dot names like "project.shotA.nk" → "project.shotA"
     # whereas split('.')[0] would give the ambiguous "project" for both shotA and shotB.
+    # Returns '' for unsaved scripts (nuke.root().name() == '').  _find_local_node()
+    # will then pass the same-script guard trivially (both source and destination stems
+    # are ''), so a local-dot FQNN like '.NodeName' still resolves — this is intentional
+    # and consistent behaviour for unsaved-script workflows.
     return os.path.splitext(os.path.basename(nuke.root().name()))[0]
 
 
@@ -68,7 +72,7 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: multiple 
                     stored_fqnn = f"{script_stem}.{get_fully_qualified_node_name(input_node)}"
                     setup_link_node(input_node, node)
                     add_input_knob(node, dot_type='local')
-                    source_label = input_node['label'].getText() or input_node.name()
+                    source_label = (input_node['label'].getText() if 'label' in input_node.knobs() else '') or input_node.name()
                     node['label'].setValue(f"Local: {source_label}")
                     node['tile_color'].setValue(LOCAL_DOT_COLOR)
                     node[KNOB_NAME].setText(stored_fqnn)
@@ -96,7 +100,7 @@ def copy_anchors(cut=False):  # noqa: C901 — complexity is inherent: multiple 
                     stored_fqnn = f"{script_stem}.{get_fully_qualified_node_name(input_node)}"
                     setup_link_node(input_node, node)
                     add_input_knob(node, dot_type='local')
-                    source_label = input_node['label'].getText() or input_node.name()
+                    source_label = (input_node['label'].getText() if 'label' in input_node.knobs() else '') or input_node.name()
                     node['label'].setValue(f"Local: {source_label}")
                     node['tile_color'].setValue(LOCAL_DOT_COLOR)
                     node[KNOB_NAME].setText(stored_fqnn)
@@ -217,7 +221,8 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
                 link_node = nuke.createNode(get_link_class_for_source(original_anchor))
                 setup_link_node(original_anchor, link_node)
                 link_node.setXYpos(node.xpos(), node.ypos())
-                final_selection.remove(node)
+                if node in final_selection:
+                    final_selection.remove(node)
                 final_selection.append(link_node)
                 nuke.delete(node)
 
@@ -276,7 +281,7 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
                     # Re-add the DOT_TYPE knob that setup_link_node stripped, then restore
                     # Local Dot appearance (label and color overwritten by setup_link_node).
                     add_input_knob(node, dot_type='local')
-                    source_label = input_node['label'].getText() or input_node.name()
+                    source_label = (input_node['label'].getText() if 'label' in input_node.knobs() else '') or input_node.name()
                     node['label'].setValue(f"Local: {source_label}")
                     node['tile_color'].setValue(LOCAL_DOT_COLOR)
 
@@ -290,19 +295,20 @@ def paste_anchors():  # noqa: C901 — complexity is inherent: anchor/link/dot p
 
 
 def paste_multiple_anchors():
-    selected_nodes = nuke.selectedNodes()
-    new_selection = []
+    with nuke.lastHitGroup():
+        selected_nodes = nuke.selectedNodes()
+        new_selection = []
 
-    for node in selected_nodes:
+        for node in selected_nodes:
+            nukescripts.clear_selection_recursive()
+            node["selected"].setValue(True)
+            paste_anchors()
+
+            new_selection.extend(nuke.selectedNodes())
+
         nukescripts.clear_selection_recursive()
-        node["selected"].setValue(True)
-        paste_anchors()
-
-        new_selection.extend(nuke.selectedNodes())
-
-    nukescripts.clear_selection_recursive()
-    for node in new_selection:
-        node["selected"].setValue(True)
+        for node in new_selection:
+            node["selected"].setValue(True)
 
 
 def migrate_script():

--- a/link.py
+++ b/link.py
@@ -34,10 +34,12 @@ def get_fully_qualified_node_name(node):
 
 
 def find_node_default_color(node):
-    prefs = nuke.toNode("preferences")
+    prefs_node = nuke.toNode("preferences")
+    if prefs_node is None:
+        return 0
     node_colour_slots = [
-        prefs[knob_name].value().split(' ')
-        for knob_name in prefs.knobs()
+        prefs_node[knob_name].value().split(' ')
+        for knob_name in prefs_node.knobs()
         if knob_name.startswith("NodeColourSlot")
     ]
     node_colour_slots = [
@@ -45,14 +47,14 @@ def find_node_default_color(node):
         for parent_item in node_colour_slots
     ]
     node_colour_choices = [
-        prefs[knob_name].value()
-        for knob_name in prefs.knobs()
+        prefs_node[knob_name].value()
+        for knob_name in prefs_node.knobs()
         if knob_name.startswith("NodeColourChoice")
     ]
     for i, slot in enumerate(node_colour_slots):
         if node.Class().lower() in slot:
             return node_colour_choices[i]
-    return prefs["NodeColor"].value()
+    return prefs_node["NodeColor"].value()
 
 
 def find_node_color(node):
@@ -184,10 +186,8 @@ def setup_link_node(input_node, link_node):
     link_node["hide_input"].setValue(True)
     link_node["tile_color"].setValue(find_node_color(input_node))
 
-    if input_node["label"].getText():
-        link_node["label"].setValue(f"Link: {input_node['label'].getText()}")
-    else:
-        link_node["label"].setValue(f"Link: {input_node.name()}")
+    label_text = input_node['label'].getText() if 'label' in input_node.knobs() else ''
+    link_node["label"].setValue(f"Link: {label_text}" if label_text else f"Link: {input_node.name()}")
 
     if link_node.Class() == 'Dot':
         link_node["note_font_size"].setValue(DOT_LINK_LABEL_FONT_SIZE)

--- a/tests/test_paste_robustness.py
+++ b/tests/test_paste_robustness.py
@@ -1,0 +1,392 @@
+"""Tests for paste robustness crash-guard fixes (issue #38).
+
+Covers:
+- TEST-38-01: final_selection.remove() does not raise when node appears twice
+- TEST-38-02: find_node_default_color() returns 0 when prefs node is None
+- TEST-38-03: paste_multiple_anchors() completes without error (smoke test)
+- TEST-38-04: _get_script_stem() returns '' for unsaved scripts
+- TEST-38-05: setup_link_node() does not raise when input_node lacks a 'label' knob
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# TEST-38-01: final_selection.remove() guard in paste_anchors() Path D
+# ---------------------------------------------------------------------------
+
+class TestFinalSelectionRemoveGuard(unittest.TestCase):
+    """CRASH-01: final_selection.remove() must not raise ValueError when the
+    same node appears twice in the pasted selection (or is already absent)."""
+
+    def _make_stamped_anchor_node(self, anchor_name, stored_fqnn):
+        """Return a stub anchor node stamped with DOT_TYPE='link' (Path D trigger)."""
+        import nuke as _nuke
+        from constants import KNOB_NAME, DOT_TYPE_KNOB_NAME, ANCHOR_PREFIX
+        return _nuke.StubNode(
+            name=ANCHOR_PREFIX + anchor_name,
+            node_class='NoOp',
+            xpos=100,
+            ypos=200,
+            knobs_dict={
+                KNOB_NAME: _nuke.StubKnob(stored_fqnn),
+                DOT_TYPE_KNOB_NAME: _nuke.StubKnob('link'),
+                'selected': _nuke.StubKnob(False),
+            },
+        )
+
+    def test_duplicate_node_in_pasted_selection_does_not_raise(self):
+        """When the same node object appears twice in nuke.selectedNodes(), the
+        guarded final_selection.remove() must not raise ValueError."""
+        import nuke as _nuke
+        from constants import KNOB_NAME
+
+        anchor_node = self._make_stamped_anchor_node(
+            anchor_name='MyFootage',
+            stored_fqnn='Anchor_MyFootage',
+        )
+
+        # Simulate Nuke returning the same node object twice in the pasted selection.
+        duplicate_selection = [anchor_node, anchor_node]
+
+        resolved_original = _nuke.StubNode(
+            name='Anchor_MyFootage',
+            node_class='NoOp',
+            knobs_dict={
+                'tile_color': _nuke.StubKnob(0),
+                'label': _nuke.StubKnob(''),
+                'hide_input': _nuke.StubKnob(False),
+            },
+        )
+
+        created_link_nodes = []
+
+        def fake_create_node(node_class):
+            link_node = _nuke.StubNode(
+                name=f'NoOp_link_{len(created_link_nodes)}',
+                node_class=node_class,
+                knobs_dict={'selected': _nuke.StubKnob(False)},
+            )
+            created_link_nodes.append(link_node)
+            return link_node
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.find_anchor_node', return_value=resolved_original), \
+             patch('anchors.is_anchor', return_value=True), \
+             patch('anchors.get_link_class_for_source', return_value='NoOp'), \
+             patch('anchors.setup_link_node'):
+
+            mock_nuke.nodePaste.return_value = None
+            mock_nuke.selectedNodes.return_value = duplicate_selection
+            mock_nuke.createNode.side_effect = fake_create_node
+            mock_nuke.delete = MagicMock()
+
+            from anchors import paste_anchors
+
+            # Must not raise ValueError
+            try:
+                paste_anchors()
+            except ValueError as exc:
+                self.fail(
+                    f"paste_anchors() raised ValueError when node appeared twice "
+                    f"in selection: {exc}"
+                )
+
+    def test_node_already_absent_from_final_selection_does_not_raise(self):
+        """If a node was already removed from final_selection by a prior iteration,
+        the guard must silently skip the second remove() instead of raising."""
+        # Build a list and manually test the guarded pattern to confirm no ValueError.
+        final_selection = ['node_a', 'node_b']
+        node_to_remove = 'node_a'
+
+        # First removal — succeeds
+        if node_to_remove in final_selection:
+            final_selection.remove(node_to_remove)
+
+        # Second removal attempt — guarded, must not raise
+        try:
+            if node_to_remove in final_selection:
+                final_selection.remove(node_to_remove)
+        except ValueError as exc:
+            self.fail(f"Guarded remove raised ValueError: {exc}")
+
+        self.assertEqual(final_selection, ['node_b'])
+
+
+# ---------------------------------------------------------------------------
+# TEST-38-02: find_node_default_color() returns 0 when preferences is None
+# ---------------------------------------------------------------------------
+
+class TestFindNodeDefaultColorNullPrefs(unittest.TestCase):
+    """CRASH-02: find_node_default_color() must return 0 gracefully when
+    nuke.toNode('preferences') returns None (headless / degraded session)."""
+
+    def test_returns_zero_when_preferences_node_is_none(self):
+        """find_node_default_color() must return 0 when prefs_node is None."""
+        import nuke as _nuke
+        from tests.stubs import make_stub_nuke_module
+
+        stub_nuke = make_stub_nuke_module()
+        stub_nuke.toNode = MagicMock(return_value=None)
+
+        input_node = _nuke.StubNode(
+            name='Read1',
+            node_class='Read',
+            knobs_dict={
+                'tile_color': _nuke.StubKnob(0),
+            },
+        )
+
+        with patch('link.nuke', stub_nuke):
+            from link import find_node_default_color
+            result = find_node_default_color(input_node)
+
+        self.assertEqual(
+            result,
+            0,
+            f"Expected 0 when preferences is None, got {result!r}",
+        )
+
+    def test_does_not_raise_when_preferences_node_is_none(self):
+        """find_node_default_color() must not raise AttributeError when prefs is None."""
+        import nuke as _nuke
+        from tests.stubs import make_stub_nuke_module
+
+        stub_nuke = make_stub_nuke_module()
+        stub_nuke.toNode = MagicMock(return_value=None)
+
+        input_node = _nuke.StubNode(name='Camera1', node_class='Camera')
+
+        with patch('link.nuke', stub_nuke):
+            from link import find_node_default_color
+            try:
+                find_node_default_color(input_node)
+            except AttributeError as exc:
+                self.fail(
+                    f"find_node_default_color() raised AttributeError with None prefs: {exc}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# TEST-38-03: paste_multiple_anchors() smoke test
+# ---------------------------------------------------------------------------
+
+class TestPasteMultipleAnchorsSmoke(unittest.TestCase):
+    """CRASH-03: paste_multiple_anchors() must complete without error and must
+    operate inside a nuke.lastHitGroup() context."""
+
+    def test_paste_multiple_anchors_completes_without_error(self):
+        """Basic smoke test: paste_multiple_anchors() with two selected nodes
+        must run to completion without raising any exception."""
+        import nuke as _nuke
+
+        node_a = _nuke.StubNode(
+            name='NoOp1',
+            node_class='NoOp',
+            knobs_dict={'selected': _nuke.StubKnob(False)},
+        )
+        node_b = _nuke.StubNode(
+            name='NoOp2',
+            node_class='NoOp',
+            knobs_dict={'selected': _nuke.StubKnob(False)},
+        )
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.paste_anchors') as mock_paste_anchors:
+
+            mock_nuke.selectedNodes.return_value = [node_a, node_b]
+            mock_paste_anchors.return_value = None
+
+            # lastHitGroup must return a context manager
+            mock_context = MagicMock()
+            mock_context.__enter__ = MagicMock(return_value=None)
+            mock_context.__exit__ = MagicMock(return_value=False)
+            mock_nuke.lastHitGroup.return_value = mock_context
+
+            from anchors import paste_multiple_anchors
+
+            try:
+                paste_multiple_anchors()
+            except Exception as exc:
+                self.fail(f"paste_multiple_anchors() raised unexpectedly: {exc}")
+
+    def test_paste_multiple_anchors_uses_last_hit_group_context(self):
+        """paste_multiple_anchors() must call nuke.lastHitGroup() so that
+        selectedNodes() operates in the user's last-active group context."""
+        import nuke as _nuke
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.paste_anchors'):
+
+            mock_nuke.selectedNodes.return_value = []
+
+            mock_context = MagicMock()
+            mock_context.__enter__ = MagicMock(return_value=None)
+            mock_context.__exit__ = MagicMock(return_value=False)
+            mock_nuke.lastHitGroup.return_value = mock_context
+
+            from anchors import paste_multiple_anchors
+            paste_multiple_anchors()
+
+            mock_nuke.lastHitGroup.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TEST-38-04: _get_script_stem() returns '' for unsaved scripts
+# ---------------------------------------------------------------------------
+
+class TestGetScriptStemUnsaved(unittest.TestCase):
+    """CRASH-04: _get_script_stem() must return '' when nuke.root().name() is ''
+    (script has never been saved)."""
+
+    def test_returns_empty_string_for_unsaved_script(self):
+        """_get_script_stem() must return '' when nuke.root().name() returns ''."""
+        with patch('anchors.nuke') as mock_nuke:
+            mock_nuke.root.return_value.name.return_value = ''
+
+            from anchors import _get_script_stem
+            result = _get_script_stem()
+
+        self.assertEqual(
+            result,
+            '',
+            f"Expected '' for unsaved script, got {result!r}",
+        )
+
+    def test_returns_stem_for_saved_script(self):
+        """_get_script_stem() must return the bare filename stem for a saved script."""
+        with patch('anchors.nuke') as mock_nuke:
+            mock_nuke.root.return_value.name.return_value = '/path/to/myScript.nk'
+
+            from anchors import _get_script_stem
+            result = _get_script_stem()
+
+        self.assertEqual(result, 'myScript')
+
+    def test_returns_multi_dot_stem_correctly(self):
+        """_get_script_stem() must preserve all segments before the final extension
+        for multi-dot filenames like 'project.shotA.nk'."""
+        with patch('anchors.nuke') as mock_nuke:
+            mock_nuke.root.return_value.name.return_value = '/path/to/project.shotA.nk'
+
+            from anchors import _get_script_stem
+            result = _get_script_stem()
+
+        self.assertEqual(result, 'project.shotA')
+
+
+# ---------------------------------------------------------------------------
+# TEST-38-05: setup_link_node() does not raise when input_node lacks 'label'
+# ---------------------------------------------------------------------------
+
+class TestSetupLinkNodeNoLabelKnob(unittest.TestCase):
+    """CRASH-05: setup_link_node() must not raise when input_node has no 'label'
+    knob (custom Gizmo or TCL node that omits the standard label knob)."""
+
+    def _make_node_without_label(self, name='Gizmo1', node_class='NoOp'):
+        """Return a stub node that deliberately has no 'label' knob."""
+        import nuke as _nuke
+        return _nuke.StubNode(
+            name=name,
+            node_class=node_class,
+            knobs_dict={
+                'tile_color': _nuke.StubKnob(0),
+                'hide_input': _nuke.StubKnob(False),
+                # Intentionally NO 'label' knob
+            },
+        )
+
+    def _make_link_node(self, name='NoOp_link', node_class='NoOp'):
+        """Return a stub node that will serve as the link node."""
+        import nuke as _nuke
+        from constants import KNOB_NAME
+        return _nuke.StubNode(
+            name=name,
+            node_class=node_class,
+            knobs_dict={
+                'tile_color': _nuke.StubKnob(0),
+                'hide_input': _nuke.StubKnob(False),
+                'label': _nuke.StubKnob(''),
+                'note_font_size': _nuke.StubKnob(0),
+                KNOB_NAME: _nuke.StubKnob(''),
+            },
+        )
+
+    def test_does_not_raise_when_input_node_has_no_label_knob(self):
+        """setup_link_node() must not raise NameError when input_node lacks 'label'."""
+        from tests.stubs import make_stub_nuke_module
+
+        input_node = self._make_node_without_label()
+        link_node = self._make_link_node()
+
+        stub_nuke = make_stub_nuke_module()
+
+        with patch('link.nuke', stub_nuke), \
+             patch('link.find_node_color', return_value=0):
+            from link import setup_link_node
+
+            try:
+                setup_link_node(input_node, link_node)
+            except (NameError, KeyError) as exc:
+                self.fail(
+                    f"setup_link_node() raised {type(exc).__name__} when input_node "
+                    f"had no 'label' knob: {exc}"
+                )
+
+    def test_uses_node_name_as_label_when_input_has_no_label_knob(self):
+        """When input_node has no 'label' knob, the link label must fall back to
+        'Link: <input_node.name()>'."""
+        from tests.stubs import make_stub_nuke_module
+
+        input_node = self._make_node_without_label(name='MyCustomGizmo')
+        link_node = self._make_link_node()
+
+        stub_nuke = make_stub_nuke_module()
+
+        with patch('link.nuke', stub_nuke), \
+             patch('link.find_node_color', return_value=0):
+            from link import setup_link_node
+            setup_link_node(input_node, link_node)
+
+        self.assertEqual(
+            link_node['label'].getValue(),
+            'Link: MyCustomGizmo',
+        )
+
+    def test_uses_label_text_when_input_has_label_knob_with_value(self):
+        """When input_node has a 'label' knob with a non-empty value, the link label
+        must be 'Link: <label_text>'."""
+        import nuke as _nuke
+        from tests.stubs import make_stub_nuke_module
+
+        input_node = _nuke.StubNode(
+            name='Read1',
+            node_class='Read',
+            knobs_dict={
+                'tile_color': _nuke.StubKnob(0),
+                'hide_input': _nuke.StubKnob(False),
+                'label': _nuke.StubKnob('my footage'),
+            },
+        )
+        link_node = self._make_link_node()
+
+        stub_nuke = make_stub_nuke_module()
+
+        with patch('link.nuke', stub_nuke), \
+             patch('link.find_node_color', return_value=0):
+            from link import setup_link_node
+            setup_link_node(input_node, link_node)
+
+        self.assertEqual(
+            link_node['label'].getValue(),
+            'Link: my footage',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_paste_robustness.py
+++ b/tests/test_paste_robustness.py
@@ -8,7 +8,6 @@ Covers:
 - TEST-38-05: setup_link_node() does not raise when input_node lacks a 'label' knob
 """
 
-import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -73,7 +72,7 @@ class TestFinalSelectionRemoveGuard(unittest.TestCase):
             return link_node
 
         with patch('anchors.nuke') as mock_nuke, \
-             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.nukescripts'), \
              patch('anchors.find_anchor_node', return_value=resolved_original), \
              patch('anchors.is_anchor', return_value=True), \
              patch('anchors.get_link_class_for_source', return_value='NoOp'), \
@@ -195,7 +194,7 @@ class TestPasteMultipleAnchorsSmoke(unittest.TestCase):
         )
 
         with patch('anchors.nuke') as mock_nuke, \
-             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.nukescripts'), \
              patch('anchors.paste_anchors') as mock_paste_anchors:
 
             mock_nuke.selectedNodes.return_value = [node_a, node_b]
@@ -217,10 +216,8 @@ class TestPasteMultipleAnchorsSmoke(unittest.TestCase):
     def test_paste_multiple_anchors_uses_last_hit_group_context(self):
         """paste_multiple_anchors() must call nuke.lastHitGroup() so that
         selectedNodes() operates in the user's last-active group context."""
-        import nuke as _nuke
-
         with patch('anchors.nuke') as mock_nuke, \
-             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.nukescripts'), \
              patch('anchors.paste_anchors'):
 
             mock_nuke.selectedNodes.return_value = []


### PR DESCRIPTION
## Summary

Fixes five intermittent crash causes identified in `docs/plans/plan_issue_38.md`:

- **CRASH-01** (`anchors.py` Path D): `final_selection.remove(node)` raised `ValueError` when Nuke returned the same node object twice in `selectedNodes()`. Now guarded with `if node in final_selection:`.

- **CRASH-02** (`link.py`): `find_node_default_color()` crashed with `AttributeError` when `nuke.toNode("preferences")` returned `None` (headless sessions, early startup). Renamed local to `prefs_node` and added a `None` guard that returns `0`.

- **CRASH-03** (`anchors.py`): `paste_multiple_anchors()` called `nuke.selectedNodes()` outside any `with nuke.lastHitGroup():` context. When triggered from a Group's floating DAG panel, this caused all node operations to act on the wrong group context. Wrapped the entire function body in `with nuke.lastHitGroup():`.

- **CRASH-04** (`anchors.py`): Added a comment to `_get_script_stem()` documenting the empty-string return for unsaved scripts and explaining that `_find_local_node()` passes the same-script guard trivially in that case. No functional change.

- **CRASH-05** (`link.py`, `anchors.py`): `setup_link_node()` and three `copy_anchors()` sites accessed `input_node['label']` without checking whether the knob exists. Custom Gizmos or TCL-defined nodes that omit the standard `label` knob would raise `NameError`. All four sites now guard with `'label' in input_node.knobs()`.

## Test plan

- [x] `tests/test_paste_robustness.py` added with 12 new tests covering all five cases (TEST-38-01 through TEST-38-05)
- [x] Full test suite: 334/334 passed (`python3 -m pytest tests/ -x -q`)
- [x] Pre-commit hook passed on commit

Closes #38