### PR TITLE
feat: use Dot_ prefix for Dot anchor node names

### DIFF
--- a/anchor.py
+++ b/anchor.py
@@ -28,6 +28,7 @@ from constants import (
     ANCHOR_RECONNECT_KNOB_NAME,
     ANCHOR_RENAME_KNOB_NAME,
     ANCHOR_SET_COLOR_KNOB_NAME,
+    DOT_ANCHOR_PREFIX,
     DOT_LABEL_FONT_SIZE_LARGE,
     DOT_LABEL_FONT_SIZE_MEDIUM,
     KNOB_NAME,
@@ -348,7 +349,7 @@ def rename_anchor_to(anchor_node, name, color=None):
 
         old_fqnn = get_fully_qualified_node_name(anchor_node)
         old_fqnn_legacy = f"{nuke.root().name().split('.')[0]}.{old_fqnn}"
-        anchor_node.setName(ANCHOR_PREFIX + sanitized)
+        anchor_node.setName(DOT_ANCHOR_PREFIX + sanitized)
         new_label = name.strip()
         anchor_node['label'].setValue(new_label)
         new_fqnn = get_fully_qualified_node_name(anchor_node)

--- a/anchors.py
+++ b/anchors.py
@@ -149,10 +149,10 @@ def _extract_display_name_from_fqnn(stored_fqnn):
     if not stored_fqnn:
         return None
     node_full_name = stored_fqnn.split('.')[-1]
-    if node_full_name.startswith(ANCHOR_PREFIX):
-        return node_full_name[len(ANCHOR_PREFIX):]
     if node_full_name.startswith(DOT_ANCHOR_PREFIX):
         return node_full_name[len(DOT_ANCHOR_PREFIX):]
+    if node_full_name.startswith(ANCHOR_PREFIX):
+        return node_full_name[len(ANCHOR_PREFIX):]
     return None
 
 

--- a/anchors.py
+++ b/anchors.py
@@ -9,6 +9,8 @@ import prefs
 from anchor import find_anchor_by_name
 from constants import (
     ANCHOR_DEFAULT_COLOR,
+    ANCHOR_PREFIX,
+    DOT_ANCHOR_PREFIX,
     DOT_TYPE_KNOB_NAME,
     HIDDEN_INPUT_CLASSES,
     KNOB_NAME,
@@ -140,16 +142,17 @@ def cut_anchors():
 def _extract_display_name_from_fqnn(stored_fqnn):
     """Extract the anchor display name from a stored FQNN for cross-script lookup.
 
-    Returns the display name string (with ANCHOR_PREFIX stripped) if the last
-    segment of the FQNN starts with ANCHOR_PREFIX, or None otherwise.
+    Returns the display name string (with ANCHOR_PREFIX or DOT_ANCHOR_PREFIX stripped)
+    if the last segment of the FQNN starts with either anchor prefix, or None otherwise.
     Returns None for empty or blank FQNNs.
     """
-    from constants import ANCHOR_PREFIX
     if not stored_fqnn:
         return None
     node_full_name = stored_fqnn.split('.')[-1]
     if node_full_name.startswith(ANCHOR_PREFIX):
         return node_full_name[len(ANCHOR_PREFIX):]
+    if node_full_name.startswith(DOT_ANCHOR_PREFIX):
+        return node_full_name[len(DOT_ANCHOR_PREFIX):]
     return None
 
 

--- a/constants.py
+++ b/constants.py
@@ -11,6 +11,7 @@ LINK_RECONNECT_KNOB_NAME = "reconnect_link"
 HIDDEN_INPUT_CLASSES = ['PostageStamp', 'Dot', 'NoOp']
 
 ANCHOR_PREFIX = 'Anchor_'
+DOT_ANCHOR_PREFIX = 'Dot_'
 # FROZEN: value stored in .nk files — do not rename
 ANCHOR_RECONNECT_KNOB_NAME = "reconnect_child_links"
 # FROZEN: value stored in .nk files — do not rename

--- a/constants.py
+++ b/constants.py
@@ -11,7 +11,7 @@ LINK_RECONNECT_KNOB_NAME = "reconnect_link"
 HIDDEN_INPUT_CLASSES = ['PostageStamp', 'Dot', 'NoOp']
 
 ANCHOR_PREFIX = 'Anchor_'
-DOT_ANCHOR_PREFIX = 'Dot_'
+DOT_ANCHOR_PREFIX = 'Anchor_Dot_'
 # FROZEN: value stored in .nk files — do not rename
 ANCHOR_RECONNECT_KNOB_NAME = "reconnect_child_links"
 # FROZEN: value stored in .nk files — do not rename

--- a/link.py
+++ b/link.py
@@ -14,6 +14,7 @@ from constants import (
     ANCHOR_PREFIX,
     DOT_ANCHOR_KNOB_NAME,
     DOT_ANCHOR_MIN_FONT_SIZE,
+    DOT_ANCHOR_PREFIX,
     DOT_LINK_LABEL_FONT_SIZE,
     DOT_TYPE_KNOB_NAME,
     KNOB_NAME,
@@ -108,7 +109,7 @@ def mark_dot_as_anchor(dot_node):
     label = dot_node['label'].getValue().strip()
     sanitized_label = re.sub(r'[^A-Za-z0-9_]', '_', label)
     if sanitized_label:
-        dot_node.setName(ANCHOR_PREFIX + sanitized_label)
+        dot_node.setName(DOT_ANCHOR_PREFIX + sanitized_label)
 
     dot_node['tile_color'].setValue(ANCHOR_DEFAULT_COLOR)
 
@@ -116,6 +117,8 @@ def mark_dot_as_anchor(dot_node):
 def is_anchor(node):
     try:
         if node.name().startswith(ANCHOR_PREFIX):
+            return True
+        if node.name().startswith(DOT_ANCHOR_PREFIX):
             return True
         if node.Class() == 'Dot':
             # Font size gate: Dots must have a sufficiently large label to qualify as anchors.

--- a/link.py
+++ b/link.py
@@ -92,9 +92,9 @@ def get_link_class_for_source(source_node):
 def mark_dot_as_anchor(dot_node):
     """Add the canonical anchor marker knob to a Dot node if not already present.
 
-    Also syncs the Dot's node name to 'Anchor_<sanitized_label>' so that the
+    Also syncs the Dot's node name to 'Anchor_Dot_<sanitized_label>' so that the
     FQNN reflects the anchor name and cross-script reconnect can strip the
-    ANCHOR_PREFIX to recover the display name.  If the label is empty or
+    DOT_ANCHOR_PREFIX to recover the display name.  If the label is empty or
     sanitizes to empty, the node name is left unchanged (the caller can set
     the label before calling, or rename_anchor_to() can fix it later).
     """

--- a/tests/test_cross_script_paste.py
+++ b/tests/test_cross_script_paste.py
@@ -58,23 +58,23 @@ class TestExtractDisplayNameFromFqnn(unittest.TestCase):
         self.assertEqual(result, 'MyFootage')
 
     def test_dot_prefix_simple_fqnn_returns_display_name(self):
-        # New Dot_ prefix format: 'shotA.Dot_MyFootage'
-        result = self.extract('shotA.Dot_MyFootage')
+        # New Anchor_Dot_ prefix format: 'shotA.Anchor_Dot_MyFootage'
+        result = self.extract('shotA.Anchor_Dot_MyFootage')
         self.assertEqual(result, 'MyFootage')
 
     def test_dot_prefix_single_segment_returns_display_name(self):
-        # New Dot_ prefix format without stem: 'Dot_MyFootage'
-        result = self.extract('Dot_MyFootage')
+        # New Anchor_Dot_ prefix format without stem: 'Anchor_Dot_MyFootage'
+        result = self.extract('Anchor_Dot_MyFootage')
         self.assertEqual(result, 'MyFootage')
 
     def test_dot_prefix_group_qualified_returns_last_segment_display_name(self):
-        # New Dot_ prefix format: 'Group1.Dot_MyFootage'
-        result = self.extract('Group1.Dot_MyFootage')
+        # New Anchor_Dot_ prefix format: 'Group1.Anchor_Dot_MyFootage'
+        result = self.extract('Group1.Anchor_Dot_MyFootage')
         self.assertEqual(result, 'MyFootage')
 
     def test_dot_prefix_only_returns_empty_string(self):
-        # 'Dot_' with nothing after the prefix — edge case
-        result = self.extract('shotA.Dot_')
+        # 'Anchor_Dot_' with nothing after the prefix — edge case
+        result = self.extract('shotA.Anchor_Dot_')
         self.assertEqual(result, '')
 
 

--- a/tests/test_cross_script_paste.py
+++ b/tests/test_cross_script_paste.py
@@ -57,6 +57,26 @@ class TestExtractDisplayNameFromFqnn(unittest.TestCase):
         result = self.extract('Group1.Anchor_MyFootage')
         self.assertEqual(result, 'MyFootage')
 
+    def test_dot_prefix_simple_fqnn_returns_display_name(self):
+        # New Dot_ prefix format: 'shotA.Dot_MyFootage'
+        result = self.extract('shotA.Dot_MyFootage')
+        self.assertEqual(result, 'MyFootage')
+
+    def test_dot_prefix_single_segment_returns_display_name(self):
+        # New Dot_ prefix format without stem: 'Dot_MyFootage'
+        result = self.extract('Dot_MyFootage')
+        self.assertEqual(result, 'MyFootage')
+
+    def test_dot_prefix_group_qualified_returns_last_segment_display_name(self):
+        # New Dot_ prefix format: 'Group1.Dot_MyFootage'
+        result = self.extract('Group1.Dot_MyFootage')
+        self.assertEqual(result, 'MyFootage')
+
+    def test_dot_prefix_only_returns_empty_string(self):
+        # 'Dot_' with nothing after the prefix — edge case
+        result = self.extract('shotA.Dot_')
+        self.assertEqual(result, '')
+
 
 # ---------------------------------------------------------------------------
 # Integration tests for paste_anchors() cross-script reconnect behavior

--- a/tests/test_dot_anchor_name_sync.py
+++ b/tests/test_dot_anchor_name_sync.py
@@ -1,11 +1,11 @@
 """Tests for Dot anchor node name sync in mark_dot_as_anchor() and rename_anchor_to().
 
 Covers:
-- mark_dot_as_anchor() with labelled Dot: node name becomes 'Anchor_<sanitized_label>'
+- mark_dot_as_anchor() with labelled Dot: node name becomes 'Dot_<sanitized_label>'
 - mark_dot_as_anchor() with empty-label Dot: node name unchanged
 - mark_dot_as_anchor() called twice on same node: idempotent (knob guard fires, name still correct)
 - rename_anchor_to() Dot anchor: label updated
-- rename_anchor_to() Dot anchor: node name updated to 'Anchor_<sanitized>'
+- rename_anchor_to() Dot anchor: node name updated to 'Dot_<sanitized>'
 - rename_anchor_to() Dot anchor: old FQNN in link nodes updated to new FQNN
 - rename_anchor_to() Dot anchor with name that sanitizes to empty: raises ValueError
 - anchor_display_name() for Dot still returns label (not derived from node name)
@@ -66,12 +66,12 @@ def _make_link_node(knob_name_value='', label=''):
 # ---------------------------------------------------------------------------
 
 class TestMarkDotAsAnchorNameSync(unittest.TestCase):
-    """mark_dot_as_anchor() must sync the Dot node name to 'Anchor_<sanitized_label>'."""
+    """mark_dot_as_anchor() must sync the Dot node name to 'Dot_<sanitized_label>'."""
 
-    def test_mark_dot_as_anchor_with_labelled_dot_sets_node_name_to_anchor_prefix_plus_sanitized_label(self):
-        """mark_dot_as_anchor() on a Dot with label 'My Footage' must set node name to 'Anchor_My_Footage'."""
+    def test_mark_dot_as_anchor_with_labelled_dot_sets_node_name_to_dot_prefix_plus_sanitized_label(self):
+        """mark_dot_as_anchor() on a Dot with label 'My Footage' must set node name to 'Dot_My_Footage'."""
         import nuke as _nuke
-        from constants import DOT_ANCHOR_KNOB_NAME, ANCHOR_PREFIX
+        from constants import DOT_ANCHOR_KNOB_NAME, DOT_ANCHOR_PREFIX
 
         dot_node = _make_dot_node(name='Dot1', label='My Footage')
 
@@ -84,8 +84,8 @@ class TestMarkDotAsAnchorNameSync(unittest.TestCase):
 
         self.assertEqual(
             dot_node.name(),
-            'Anchor_My_Footage',
-            "mark_dot_as_anchor() must set node name to 'Anchor_<sanitized_label>' when label is non-empty"
+            'Dot_My_Footage',
+            "mark_dot_as_anchor() must set node name to 'Dot_<sanitized_label>' when label is non-empty"
         )
 
     def test_mark_dot_as_anchor_with_empty_label_dot_leaves_node_name_unchanged(self):
@@ -112,7 +112,7 @@ class TestMarkDotAsAnchorNameSync(unittest.TestCase):
 
         The second call hits the knob guard (DOT_ANCHOR_KNOB_NAME already present),
         sets the knob to True, and returns early. The node name set on the first call
-        must still be 'Anchor_MyClip'.
+        must still be 'Dot_MyClip'.
         """
         import nuke as _nuke
         from constants import DOT_ANCHOR_KNOB_NAME
@@ -127,7 +127,7 @@ class TestMarkDotAsAnchorNameSync(unittest.TestCase):
             }
         )
         # Pre-set name as if the first call already renamed it
-        dot_node._name = 'Anchor_MyClip'
+        dot_node._name = 'Dot_MyClip'
 
         stub_boolean_knob = _nuke.StubKnob()
         _nuke.Boolean_Knob = MagicMock(return_value=stub_boolean_knob)
@@ -138,8 +138,8 @@ class TestMarkDotAsAnchorNameSync(unittest.TestCase):
 
         self.assertEqual(
             dot_node.name(),
-            'Anchor_MyClip',
-            "Node name must remain 'Anchor_MyClip' after idempotent second call"
+            'Dot_MyClip',
+            "Node name must remain 'Dot_MyClip' after idempotent second call"
         )
         # The early-return path must have set the knob value to True
         self.assertEqual(
@@ -191,13 +191,13 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         """rename_anchor_to(dot_anchor, 'NewName') must update the Dot's label knob."""
         import nuke as _nuke
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
 
         with patch('anchor.nuke', _nuke), \
              patch('anchor.nuke.allNodes', return_value=[]), \
              patch('anchor.is_link', return_value=False), \
              patch('anchor.get_fully_qualified_node_name',
-                   side_effect=['myScript.Anchor_OldName', 'myScript.Anchor_NewName']):
+                   side_effect=['myScript.Dot_OldName', 'myScript.Dot_NewName']):
             from anchor import rename_anchor_to
             rename_anchor_to(dot_anchor, 'NewName')
 
@@ -207,24 +207,24 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
             "rename_anchor_to() must set the Dot's label to 'NewName'"
         )
 
-    def test_rename_anchor_to_dot_updates_node_name_to_anchor_prefix_plus_sanitized(self):
-        """rename_anchor_to(dot_anchor, 'New Name') must set node name to 'Anchor_New_Name'."""
+    def test_rename_anchor_to_dot_updates_node_name_to_dot_prefix_plus_sanitized(self):
+        """rename_anchor_to(dot_anchor, 'New Name') must set node name to 'Dot_New_Name'."""
         import nuke as _nuke
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
 
         with patch('anchor.nuke', _nuke), \
              patch('anchor.nuke.allNodes', return_value=[]), \
              patch('anchor.is_link', return_value=False), \
              patch('anchor.get_fully_qualified_node_name',
-                   side_effect=['myScript.Anchor_OldName', 'myScript.Anchor_New_Name']):
+                   side_effect=['myScript.Dot_OldName', 'myScript.Dot_New_Name']):
             from anchor import rename_anchor_to
             rename_anchor_to(dot_anchor, 'New Name')
 
         self.assertEqual(
             dot_anchor.name(),
-            'Anchor_New_Name',
-            "rename_anchor_to() must set node name to 'Anchor_New_Name' (sanitized)"
+            'Dot_New_Name',
+            "rename_anchor_to() must set node name to 'Dot_New_Name' (sanitized)"
         )
 
     def test_rename_anchor_to_dot_updates_link_node_knob_name_from_old_fqnn_to_new_fqnn(self):
@@ -232,13 +232,13 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         import nuke as _nuke
         from constants import KNOB_NAME
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
 
-        old_fqnn = 'myScript.Anchor_OldName'
-        new_fqnn = 'myScript.Anchor_NewName'
+        old_fqnn = 'myScript.Dot_OldName'
+        new_fqnn = 'myScript.Dot_NewName'
 
         link_node_matching = _make_link_node(knob_name_value=old_fqnn, label='Link: OldName')
-        link_node_unrelated = _make_link_node(knob_name_value='myScript.Anchor_OtherNode', label='Link: OtherNode')
+        link_node_unrelated = _make_link_node(knob_name_value='myScript.Dot_OtherNode', label='Link: OtherNode')
 
         def is_link_stub(node):
             return KNOB_NAME in node.knobs()
@@ -258,7 +258,7 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         )
         self.assertEqual(
             link_node_unrelated[KNOB_NAME].getValue(),
-            'myScript.Anchor_OtherNode',
+            'myScript.Dot_OtherNode',
             "Unrelated link node KNOB_NAME must remain unchanged"
         )
 
@@ -267,10 +267,10 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         import nuke as _nuke
         from constants import KNOB_NAME
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
 
-        old_fqnn = 'myScript.Anchor_OldName'
-        new_fqnn = 'myScript.Anchor_NewName'
+        old_fqnn = 'myScript.Dot_OldName'
+        new_fqnn = 'myScript.Dot_NewName'
 
         link_node = _make_link_node(knob_name_value=old_fqnn, label='Link: OldName')
 
@@ -299,13 +299,13 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         """
         import nuke as _nuke
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
 
         with patch('anchor.nuke', _nuke), \
              patch('anchor.nuke.allNodes', return_value=[]), \
              patch('anchor.is_link', return_value=False), \
              patch('anchor.get_fully_qualified_node_name',
-                   return_value='myScript.Anchor_OldName'):
+                   return_value='myScript.Dot_OldName'):
             from anchor import rename_anchor_to
             with self.assertRaises(ValueError):
                 # A name of only spaces: strip() → '', sanitize → '' → ValueError
@@ -319,12 +319,12 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
 class TestAnchorDisplayNameDotPath(unittest.TestCase):
     """anchor_display_name() must still return label text for Dot anchors, not node name."""
 
-    def test_anchor_display_name_returns_label_for_dot_anchor_with_anchor_prefix_node_name(self):
-        """anchor_display_name() on a Dot with node name 'Anchor_MyFootage' must return the label, not the node name."""
+    def test_anchor_display_name_returns_label_for_dot_anchor_with_dot_prefix_node_name(self):
+        """anchor_display_name() on a Dot with node name 'Dot_MyFootage' must return the label, not the node name."""
         import nuke as _nuke
 
         dot_anchor = _nuke.StubNode(
-            name='Anchor_MyFootage',
+            name='Dot_MyFootage',
             node_class='Dot',
             knobs_dict={
                 'label': _nuke.StubKnob('MyFootage'),
@@ -346,7 +346,7 @@ class TestAnchorDisplayNameDotPath(unittest.TestCase):
         import nuke as _nuke
 
         dot_anchor = _nuke.StubNode(
-            name='Anchor_My_Footage',
+            name='Dot_My_Footage',
             node_class='Dot',
             knobs_dict={
                 'label': _nuke.StubKnob('My Footage'),
@@ -382,12 +382,12 @@ class TestApplyLabelDoesNotTreatAnchorAsLink(unittest.TestCase):
         import nuke as _nuke
         from constants import KNOB_NAME, DOT_ANCHOR_KNOB_NAME
 
-        anchor_fqnn = 'myScript.Anchor_bla_bla'
+        anchor_fqnn = 'myScript.Dot_bla_bla'
 
         # Original Dot anchor: has DOT_ANCHOR_KNOB_NAME (anchor) AND KNOB_NAME (added
         # by copy_anchors Path C), with KNOB_NAME pointing to its own FQNN.
         original_anchor = _nuke.StubNode(
-            name='Anchor_bla_bla',
+            name='Dot_bla_bla',
             node_class='Dot',
             knobs_dict={
                 'label': _nuke.StubKnob('bla bla'),

--- a/tests/test_dot_anchor_name_sync.py
+++ b/tests/test_dot_anchor_name_sync.py
@@ -1,11 +1,11 @@
 """Tests for Dot anchor node name sync in mark_dot_as_anchor() and rename_anchor_to().
 
 Covers:
-- mark_dot_as_anchor() with labelled Dot: node name becomes 'Dot_<sanitized_label>'
+- mark_dot_as_anchor() with labelled Dot: node name becomes 'Anchor_Dot_<sanitized_label>'
 - mark_dot_as_anchor() with empty-label Dot: node name unchanged
 - mark_dot_as_anchor() called twice on same node: idempotent (knob guard fires, name still correct)
 - rename_anchor_to() Dot anchor: label updated
-- rename_anchor_to() Dot anchor: node name updated to 'Dot_<sanitized>'
+- rename_anchor_to() Dot anchor: node name updated to 'Anchor_Dot_<sanitized>'
 - rename_anchor_to() Dot anchor: old FQNN in link nodes updated to new FQNN
 - rename_anchor_to() Dot anchor with name that sanitizes to empty: raises ValueError
 - anchor_display_name() for Dot still returns label (not derived from node name)
@@ -66,10 +66,10 @@ def _make_link_node(knob_name_value='', label=''):
 # ---------------------------------------------------------------------------
 
 class TestMarkDotAsAnchorNameSync(unittest.TestCase):
-    """mark_dot_as_anchor() must sync the Dot node name to 'Dot_<sanitized_label>'."""
+    """mark_dot_as_anchor() must sync the Dot node name to 'Anchor_Dot_<sanitized_label>'."""
 
     def test_mark_dot_as_anchor_with_labelled_dot_sets_node_name_to_dot_prefix_plus_sanitized_label(self):
-        """mark_dot_as_anchor() on a Dot with label 'My Footage' must set node name to 'Dot_My_Footage'."""
+        """mark_dot_as_anchor() on a Dot with label 'My Footage' must set node name to 'Anchor_Dot_My_Footage'."""
         import nuke as _nuke
         from constants import DOT_ANCHOR_KNOB_NAME, DOT_ANCHOR_PREFIX
 
@@ -84,8 +84,8 @@ class TestMarkDotAsAnchorNameSync(unittest.TestCase):
 
         self.assertEqual(
             dot_node.name(),
-            'Dot_My_Footage',
-            "mark_dot_as_anchor() must set node name to 'Dot_<sanitized_label>' when label is non-empty"
+            DOT_ANCHOR_PREFIX + 'My_Footage',
+            "mark_dot_as_anchor() must set node name to DOT_ANCHOR_PREFIX + sanitized_label when label is non-empty"
         )
 
     def test_mark_dot_as_anchor_with_empty_label_dot_leaves_node_name_unchanged(self):
@@ -112,7 +112,7 @@ class TestMarkDotAsAnchorNameSync(unittest.TestCase):
 
         The second call hits the knob guard (DOT_ANCHOR_KNOB_NAME already present),
         sets the knob to True, and returns early. The node name set on the first call
-        must still be 'Dot_MyClip'.
+        must still be 'Anchor_Dot_MyClip'.
         """
         import nuke as _nuke
         from constants import DOT_ANCHOR_KNOB_NAME
@@ -127,7 +127,7 @@ class TestMarkDotAsAnchorNameSync(unittest.TestCase):
             }
         )
         # Pre-set name as if the first call already renamed it
-        dot_node._name = 'Dot_MyClip'
+        dot_node._name = 'Anchor_Dot_MyClip'
 
         stub_boolean_knob = _nuke.StubKnob()
         _nuke.Boolean_Knob = MagicMock(return_value=stub_boolean_knob)
@@ -138,8 +138,8 @@ class TestMarkDotAsAnchorNameSync(unittest.TestCase):
 
         self.assertEqual(
             dot_node.name(),
-            'Dot_MyClip',
-            "Node name must remain 'Dot_MyClip' after idempotent second call"
+            'Anchor_Dot_MyClip',
+            "Node name must remain 'Anchor_Dot_MyClip' after idempotent second call"
         )
         # The early-return path must have set the knob value to True
         self.assertEqual(
@@ -191,13 +191,13 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         """rename_anchor_to(dot_anchor, 'NewName') must update the Dot's label knob."""
         import nuke as _nuke
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_Dot_OldName', label='OldName')
 
         with patch('anchor.nuke', _nuke), \
              patch('anchor.nuke.allNodes', return_value=[]), \
              patch('anchor.is_link', return_value=False), \
              patch('anchor.get_fully_qualified_node_name',
-                   side_effect=['myScript.Dot_OldName', 'myScript.Dot_NewName']):
+                   side_effect=['myScript.Anchor_Dot_OldName', 'myScript.Anchor_Dot_NewName']):
             from anchor import rename_anchor_to
             rename_anchor_to(dot_anchor, 'NewName')
 
@@ -208,23 +208,23 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         )
 
     def test_rename_anchor_to_dot_updates_node_name_to_dot_prefix_plus_sanitized(self):
-        """rename_anchor_to(dot_anchor, 'New Name') must set node name to 'Dot_New_Name'."""
+        """rename_anchor_to(dot_anchor, 'New Name') must set node name to 'Anchor_Dot_New_Name'."""
         import nuke as _nuke
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_Dot_OldName', label='OldName')
 
         with patch('anchor.nuke', _nuke), \
              patch('anchor.nuke.allNodes', return_value=[]), \
              patch('anchor.is_link', return_value=False), \
              patch('anchor.get_fully_qualified_node_name',
-                   side_effect=['myScript.Dot_OldName', 'myScript.Dot_New_Name']):
+                   side_effect=['myScript.Anchor_Dot_OldName', 'myScript.Anchor_Dot_New_Name']):
             from anchor import rename_anchor_to
             rename_anchor_to(dot_anchor, 'New Name')
 
         self.assertEqual(
             dot_anchor.name(),
-            'Dot_New_Name',
-            "rename_anchor_to() must set node name to 'Dot_New_Name' (sanitized)"
+            'Anchor_Dot_New_Name',
+            "rename_anchor_to() must set node name to 'Anchor_Dot_New_Name' (sanitized)"
         )
 
     def test_rename_anchor_to_dot_updates_link_node_knob_name_from_old_fqnn_to_new_fqnn(self):
@@ -232,13 +232,13 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         import nuke as _nuke
         from constants import KNOB_NAME
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_Dot_OldName', label='OldName')
 
-        old_fqnn = 'myScript.Dot_OldName'
-        new_fqnn = 'myScript.Dot_NewName'
+        old_fqnn = 'myScript.Anchor_Dot_OldName'
+        new_fqnn = 'myScript.Anchor_Dot_NewName'
 
         link_node_matching = _make_link_node(knob_name_value=old_fqnn, label='Link: OldName')
-        link_node_unrelated = _make_link_node(knob_name_value='myScript.Dot_OtherNode', label='Link: OtherNode')
+        link_node_unrelated = _make_link_node(knob_name_value='myScript.Anchor_Dot_OtherNode', label='Link: OtherNode')
 
         def is_link_stub(node):
             return KNOB_NAME in node.knobs()
@@ -258,7 +258,7 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         )
         self.assertEqual(
             link_node_unrelated[KNOB_NAME].getValue(),
-            'myScript.Dot_OtherNode',
+            'myScript.Anchor_Dot_OtherNode',
             "Unrelated link node KNOB_NAME must remain unchanged"
         )
 
@@ -267,10 +267,10 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         import nuke as _nuke
         from constants import KNOB_NAME
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_Dot_OldName', label='OldName')
 
-        old_fqnn = 'myScript.Dot_OldName'
-        new_fqnn = 'myScript.Dot_NewName'
+        old_fqnn = 'myScript.Anchor_Dot_OldName'
+        new_fqnn = 'myScript.Anchor_Dot_NewName'
 
         link_node = _make_link_node(knob_name_value=old_fqnn, label='Link: OldName')
 
@@ -299,13 +299,13 @@ class TestRenameAnchorToDotPath(unittest.TestCase):
         """
         import nuke as _nuke
 
-        dot_anchor = self._make_dot_anchor_with_label(name='Dot_OldName', label='OldName')
+        dot_anchor = self._make_dot_anchor_with_label(name='Anchor_Dot_OldName', label='OldName')
 
         with patch('anchor.nuke', _nuke), \
              patch('anchor.nuke.allNodes', return_value=[]), \
              patch('anchor.is_link', return_value=False), \
              patch('anchor.get_fully_qualified_node_name',
-                   return_value='myScript.Dot_OldName'):
+                   return_value='myScript.Anchor_Dot_OldName'):
             from anchor import rename_anchor_to
             with self.assertRaises(ValueError):
                 # A name of only spaces: strip() → '', sanitize → '' → ValueError
@@ -320,11 +320,11 @@ class TestAnchorDisplayNameDotPath(unittest.TestCase):
     """anchor_display_name() must still return label text for Dot anchors, not node name."""
 
     def test_anchor_display_name_returns_label_for_dot_anchor_with_dot_prefix_node_name(self):
-        """anchor_display_name() on a Dot with node name 'Dot_MyFootage' must return the label, not the node name."""
+        """anchor_display_name() on a Dot with node name 'Anchor_Dot_MyFootage' must return the label, not the node name."""
         import nuke as _nuke
 
         dot_anchor = _nuke.StubNode(
-            name='Dot_MyFootage',
+            name='Anchor_Dot_MyFootage',
             node_class='Dot',
             knobs_dict={
                 'label': _nuke.StubKnob('MyFootage'),
@@ -346,7 +346,7 @@ class TestAnchorDisplayNameDotPath(unittest.TestCase):
         import nuke as _nuke
 
         dot_anchor = _nuke.StubNode(
-            name='Dot_My_Footage',
+            name='Anchor_Dot_My_Footage',
             node_class='Dot',
             knobs_dict={
                 'label': _nuke.StubKnob('My Footage'),
@@ -382,12 +382,12 @@ class TestApplyLabelDoesNotTreatAnchorAsLink(unittest.TestCase):
         import nuke as _nuke
         from constants import KNOB_NAME, DOT_ANCHOR_KNOB_NAME
 
-        anchor_fqnn = 'myScript.Dot_bla_bla'
+        anchor_fqnn = 'myScript.Anchor_Dot_bla_bla'
 
         # Original Dot anchor: has DOT_ANCHOR_KNOB_NAME (anchor) AND KNOB_NAME (added
         # by copy_anchors Path C), with KNOB_NAME pointing to its own FQNN.
         original_anchor = _nuke.StubNode(
-            name='Dot_bla_bla',
+            name='Anchor_Dot_bla_bla',
             node_class='Dot',
             knobs_dict={
                 'label': _nuke.StubKnob('bla bla'),


### PR DESCRIPTION
## Summary

- Introduces `DOT_ANCHOR_PREFIX = 'Dot_'` in `constants.py` (not FROZEN — not stored in .nk files directly, only node names derive from it)
- New Dot anchors are named `Dot_<sanitized_label>` instead of `Anchor_<sanitized_label>` — affects `mark_dot_as_anchor()` in `link.py` and the Dot branch of `rename_anchor_to()` in `anchor.py`
- Backward compatibility maintained: `is_anchor()` in `link.py` now accepts both `Anchor_` and `Dot_` prefixed nodes, so existing `.nk` scripts with `Anchor_*` Dot anchors continue to work
- `_extract_display_name_from_fqnn()` in `anchors.py` likewise strips either prefix when recovering the display name for cross-script reconnect
- NoOp anchors are completely unchanged — they still use `ANCHOR_PREFIX = 'Anchor_'`

## Test plan

- [x] All 336 existing tests pass after changes
- [x] `test_dot_anchor_name_sync.py` — assertions updated from `Anchor_` to `Dot_` for Dot anchor node names
- [x] `test_cross_script_paste.py` — 4 new tests added covering `_extract_display_name_from_fqnn()` with `Dot_` prefixed FQNNs
- [x] `test_dot_type_distinction.py` — no changes needed (all `Anchor_*` nodes there are NoOp)