### PR TITLE
feat: leader key with Set Input To… commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Build release ZIP
         run: |
           mkdir anchors
-          cp anchor.py anchors.py api.py colors.py constants.py labels.py \
+          cp anchor.py anchors.py api.py colors.py constants.py \
+             input_sets.py labels.py leader.py leader_overlay.py \
              link.py menu.py migrations.py prefs.py tabtabtab_anchors.py \
              README.md LICENSE \
              anchors/

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Press `Shift+A`, then one of the keys below:
 |---|---|
 | `Q` | Set B Input To… (opens picker; wires the new link to input 0 of the selected node, replacing whatever was there) |
 | `W` | Set A Input To… (input 1) |
-| `E` | Set Mask Input To… (resolves the mask input by name; mask is input 2 on Merge-style multi-input nodes, last input on others) |
+| `E` | Set Mask Input To… (input 2 on Merge-style multi-input nodes — `maxInputs() > 100` — last input on everything else) |
 | `R` | Set First Free Input To… (lowest free slot only — never overwrites existing wiring) |
 | `F` | Anchor Find (same as `Alt+A`) |
 | `J` | Anchor Jump (same as `Alt+J`) |
@@ -102,7 +102,7 @@ Cells grey out when their precondition isn't met for the current selection — e
 
 The overlay detects your keyboard layout via locale (AZERTY for `fr_FR` / `fr_BE`, QWERTZ for German/Swiss/Czech/Slovak/Slovenian/Croatian) and renders the letter that's actually printed on your physical key — so the `Q` cell shows `A` on AZERTY, while still triggering the same Set-B-Input action.
 
-When the plugin is disabled in Preferences, `Shift+A` still works but every anchor cell is greyed; only `,` (Preferences) stays active so you can re-enable.
+When the plugin is disabled in Preferences, the `Shift+A` shortcut is disabled along with every other gated anchor command. Re-enable from `Edit > Anchors > Anchor Preferences…`, which stays active in the menu.
 
 The existing `Alt+A`, `Alt+J`, `Alt+L`, `Alt+Z` shortcuts continue to work alongside the leader for muscle-memory parity.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,33 @@ The anchor system is a reusable named-input mechanism for the node graph.
 - `Alt+L` (or `Edit > Anchors > Cycle Links`) — with an anchor selected, cycle through each Link node that references it. After the last one, returns to the anchor.
 - `Alt+Z` (or `Edit > Anchors > Anchor Back`) — restore the DAG viewport to the position before the last Alt+A / Alt+J / Alt+L jump. Single-slot — consumes the saved position.
 
+## Leader Key
+
+`Shift+A` opens the **leader key** overlay — a translucent HUD that surfaces every anchor command as a single follow-up keystroke, with cells laid out to match your physical keyboard.
+
+Press `Shift+A`, then one of the keys below:
+
+| Key | Action |
+|---|---|
+| `Q` | Set B Input To… (opens picker; wires the new link to input 0 of the selected node, replacing whatever was there) |
+| `W` | Set A Input To… (input 1) |
+| `E` | Set Mask Input To… (resolves the mask input by name; mask is input 2 on Merge-style multi-input nodes, last input on others) |
+| `R` | Set First Free Input To… (lowest free slot only — never overwrites existing wiring) |
+| `F` | Anchor Find (same as `Alt+A`) |
+| `J` | Anchor Jump (same as `Alt+J`) |
+| `L` | Cycle Links (same as `Alt+L`) — *chaining*: stays armed so repeated `L` advances through the cycle. Any other key or a mouse click disarms. |
+| `Z` | Anchor Back (same as `Alt+Z`) |
+| `X` | Reconnect All Links |
+| `,` | Anchor Preferences |
+
+Cells grey out when their precondition isn't met for the current selection — e.g. `W` greys on a single-input node, `E` greys when no mask input exists, `R` greys when every slot is filled, `J` greys unless a Link is selected, `L` greys unless an anchor is selected, `Z` greys unless there's a saved jump-back position. Pressing a greyed key disarms the leader silently.
+
+The overlay detects your keyboard layout via locale (AZERTY for `fr_FR` / `fr_BE`, QWERTZ for German/Swiss/Czech/Slovak/Slovenian/Croatian) and renders the letter that's actually printed on your physical key — so the `Q` cell shows `A` on AZERTY, while still triggering the same Set-B-Input action.
+
+When the plugin is disabled in Preferences, `Shift+A` still works but every anchor cell is greyed; only `,` (Preferences) stays active so you can re-enable.
+
+The existing `Alt+A`, `Alt+J`, `Alt+L`, `Alt+Z` shortcuts continue to work alongside the leader for muscle-memory parity.
+
 ## Reconnecting
 
 - `Edit > Anchors > Reconnect All Links` — re-wires all link nodes in the script. Useful after a script load or merge.
@@ -127,6 +154,7 @@ For Dot anchors, applying or appending a label also propagates the change to all
 | `Ctrl+V` | Paste (hidden) |
 | `Ctrl+Shift+D` | Paste (old-style, no re-piping) |
 | `A` | Anchor shortcut (context-sensitive: create anchor, rename, or open link picker) |
+| `Shift+A` | Leader Key — opens the command overlay (see Leader Key section above) |
 | `Alt+A` | Anchor Find (navigate DAG to any anchor or labelled BackdropNode) |
 | `Alt+J` | Anchor Jump (Link → source anchor) |
 | `Alt+L` | Cycle Links (anchor → each referencing Link) |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Press `Shift+A`, then one of the keys below:
 
 Cells grey out when their precondition isn't met for the current selection — e.g. `W` greys on a single-input node, `E` greys when no mask input exists, `R` greys when every slot is filled, `J` greys unless a Link is selected, `L` greys unless an anchor is selected, `Z` greys unless there's a saved jump-back position. Pressing a greyed key disarms the leader silently.
 
-The overlay detects your keyboard layout via locale (AZERTY for `fr_FR` / `fr_BE`, QWERTZ for German/Swiss/Czech/Slovak/Slovenian/Croatian) and renders the letter that's actually printed on your physical key — so the `Q` cell shows `A` on AZERTY, while still triggering the same Set-B-Input action.
+Set your keyboard layout in `Edit > Anchors > Anchor Preferences…` (QWERTY, AZERTY, or QWERTZ). The overlay then renders the letter actually printed on your physical key — so on AZERTY the `Q` cell shows `A`, while still triggering the same Set-B-Input action.
 
 When the plugin is disabled in Preferences, the `Shift+A` shortcut is disabled along with every other gated anchor command. Re-enable from `Edit > Anchors > Anchor Preferences…`, which stays active in the menu.
 

--- a/anchor.py
+++ b/anchor.py
@@ -782,6 +782,57 @@ def _make_anchor_navigate_plugin():
     )
 
 
+def pick_anchor(on_pick, hit_group=None):
+    """Open the tabtabtab anchor picker; call *on_pick(anchor_node, hit_group)* on selection.
+
+    Reuses the same picker geometry, weights file, and item list as the
+    link-creation picker so muscle-memory ordering carries over across the
+    leader-key Set-Input-To commands.
+
+    The callback is invoked synchronously from inside the picker's invoke()
+    context — callers that need DAG focus (e.g. for nuke.zoom()) must defer
+    via QtCore.QTimer.singleShot themselves, mirroring _anchor_navigate_invoke.
+
+    Silent no-op when:
+      - The plugin is disabled (prefs.plugin_enabled is False)
+      - Qt is unavailable (headless / test environment)
+      - There are no anchors to choose from in the active group
+
+    Parameters
+    ----------
+    on_pick : callable
+        Called with (anchor_node, hit_group) when the user selects an anchor.
+    hit_group : nuke.Group or None
+        Group context for the picker.  Defaults to nuke.lastHitGroup().
+    """
+    if not prefs.plugin_enabled:
+        return
+    if QtWidgets is None:
+        return
+    if hit_group is None:
+        hit_group = nuke.lastHitGroup()
+    with hit_group:
+        if not all_anchors():
+            return
+
+    def _custom_invoke(thing, captured_hit_group):
+        anchor = thing['menuobj']
+        with captured_hit_group:
+            if nuke.exists(anchor.name()):
+                on_pick(anchor, captured_hit_group)
+
+    plugin = _AnchorPickerPlugin(
+        get_items_fn=_anchor_picker_items,
+        invoke_fn=_custom_invoke,
+        weights_filename=os.path.expanduser('~/.nuke/anchors_anchor_weights.json'),
+    )
+    plugin._hit_group = hit_group
+    widget = _tabtabtab.TabTabTabWidget(plugin, winflags=Qt.FramelessWindowHint)
+    widget.under_cursor()
+    widget.show()
+    widget.raise_()
+
+
 def anchor_shortcut():
     """If a node is selected, create an anchor from it. Otherwise, pick an anchor to create from."""
     if not prefs.plugin_enabled:

--- a/colors.py
+++ b/colors.py
@@ -665,6 +665,7 @@ else:
             self._local_naming_template = prefs_module._user_naming_template
             self._local_naming_demo_filename = prefs_module._user_naming_demo_filename
             self._local_site_config_override = prefs_module.site_config_override
+            self._local_keyboard_layout = prefs_module.keyboard_layout
             self._pre_reset_naming_snapshot = None  # (regex_text, template_text) tuple or None
             import os as os_module
             self._publish_path = (
@@ -683,6 +684,23 @@ else:
             self._plugin_checkbox = QtWidgets.QCheckBox("Enable anchors plugin")
             self._plugin_checkbox.setChecked(self._local_plugin_enabled)
             outer_layout.addWidget(self._plugin_checkbox)
+
+            # Keyboard layout dropdown
+            keyboard_layout_row = QtWidgets.QHBoxLayout()
+            keyboard_layout_label = QtWidgets.QLabel("Keyboard layout:")
+            keyboard_layout_label.setFocusPolicy(Qt.NoFocus)
+            self._keyboard_layout_combobox = QtWidgets.QComboBox()
+            self._keyboard_layout_combobox.addItem("QWERTY", "qwerty")
+            self._keyboard_layout_combobox.addItem("AZERTY (FR/BE)", "azerty")
+            self._keyboard_layout_combobox.addItem("QWERTZ (DE/AT/CH/...)", "qwertz")
+            initial_layout_index = self._keyboard_layout_combobox.findData(self._local_keyboard_layout)
+            if initial_layout_index < 0:
+                initial_layout_index = 0
+            self._keyboard_layout_combobox.setCurrentIndex(initial_layout_index)
+            keyboard_layout_row.addWidget(keyboard_layout_label)
+            keyboard_layout_row.addWidget(self._keyboard_layout_combobox)
+            keyboard_layout_row.addStretch()
+            outer_layout.addLayout(keyboard_layout_row)
 
             # ---- Anchor Naming section ----
             naming_section_label = QtWidgets.QLabel("Anchor Naming")
@@ -1195,6 +1213,15 @@ else:
             prefs_module.site_config_override = self._local_site_config_override
             # Re-apply effective values so module vars reflect the new override state
             prefs_module._apply_effective_naming_values()
+            # Flush keyboard layout pref and rebuild the leader's dispatch tables
+            # so the change applies live without a Nuke restart.
+            self._local_keyboard_layout = self._keyboard_layout_combobox.currentData()
+            prefs_module.keyboard_layout = self._local_keyboard_layout
+            try:
+                import leader
+                leader.rebuild_layout()
+            except Exception:
+                pass
             # Persist to disk (save() reads _user_naming_* shadow vars — correct)
             prefs_module.save()
             # Recolor is applied immediately in _on_edit_color (on color picker confirm),

--- a/constants.py
+++ b/constants.py
@@ -46,3 +46,26 @@ DOT_ANCHOR_MIN_FONT_SIZE = 33
 USER_PALETTE_PATH = os.path.expanduser('~/.nuke/paste_hidden_user_palette.json')
 OLD_PREFS_PATH = os.path.expanduser('~/.nuke/paste_hidden_prefs.json')
 PREFS_PATH = os.path.expanduser('~/.nuke/anchors_prefs.json')
+
+# === Leader-key bindings — single source of truth for leader.py and leader_overlay.py. ===
+# Each entry: (key_letter, action_label, row, col, kind)
+#   kind: 'single' (disarm-then-dispatch) or 'chaining' (stay-armed)
+# The key_letter must be a single uppercase ASCII letter (or ',' for the comma key).
+# Row/col positions mirror physical QWERTY geometry so the grid reads like a
+# keyboard.  Column indices are the key's position in its physical row:
+#   Row 0 (Q-row): Q=0 W=1 E=2 R=3 T=4 Y=5 U=6 I=7 O=8 P=9
+#   Row 1 (A-row): A=0 S=1 D=2 F=3 G=4 H=5 J=6 K=7 L=8 ;=9
+#   Row 2 (Z-row): Z=0 X=1 C=2 V=3 B=4 N=5 M=6 ,=7 .=8 /=9
+# Empty cells are left blank in the overlay grid.
+LEADER_BINDINGS = (
+    ('Q', 'Set B Input',     0, 0, 'single'),
+    ('W', 'Set A Input',     0, 1, 'single'),
+    ('E', 'Set Mask Input',  0, 2, 'single'),
+    ('R', 'Set First Free',  0, 3, 'single'),
+    ('F', 'Anchor Find',     1, 3, 'single'),
+    ('J', 'Anchor Jump',     1, 6, 'single'),
+    ('L', 'Cycle Links',     1, 8, 'chaining'),
+    ('Z', 'Anchor Back',     2, 0, 'single'),
+    ('X', 'Reconnect All',   2, 1, 'single'),
+    (',', 'Preferences',     2, 7, 'single'),
+)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -75,7 +75,7 @@ Press `Shift+A` to open a small floating panel that maps every anchor command to
 
 Cells go grey when the action doesn't apply to your current selection — e.g. `W` greys out on a single-input node, `J` greys unless a Link is selected. Pressing a greyed key just dismisses the panel without doing anything.
 
-The panel honours your keyboard layout: on AZERTY the `Q` cell shows `A` (and pressing the physical A key fires it), on QWERTZ the `Z` cell shows `Y`, etc.
+Set your keyboard layout in Anchor Preferences (QWERTY / AZERTY / QWERTZ). The panel then matches it: on AZERTY the `Q` cell shows `A` (and pressing the physical A key fires it), on QWERTZ the `Z` cell shows `Y`, etc.
 
 ## Copy and Paste
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -60,6 +60,23 @@ _Anchors_ differentiates between three "tiers" of anchors:
 - `Alt+J` — with a Link node selected, jump straight to its source anchor.
 - `Alt+L` — with an anchor selected, cycle through each Link node that references it. Press again to advance to the next Link; after the last Link, returns to the anchor.
 
+## Leader Key — One Key for Every Anchor Action
+
+Press `Shift+A` to open a small floating panel that maps every anchor command to a single follow-up keystroke. The cells line up like a keyboard so you can see at a glance which key does what:
+
+- `Q` / `W` / `E` — wire a new Link into the selected node's **B**, **A**, or **Mask** input. Opens the anchor picker; whatever you pick lands at that input slot, replacing anything that was wired there.
+- `R` — wire a new Link into the **lowest free input** on the selected node. Won't overwrite existing wiring.
+- `F` — Anchor Find (same as `Alt+A`).
+- `J` — Jump to source anchor (same as `Alt+J`).
+- `L` — Cycle Links (same as `Alt+L`). **L is sticky**: keep pressing `L` to step through every link. Press anything else (or click) to exit.
+- `Z` — Anchor Back (same as `Alt+Z`).
+- `X` — Reconnect All Links.
+- `,` — Open Anchor Preferences.
+
+Cells go grey when the action doesn't apply to your current selection — e.g. `W` greys out on a single-input node, `J` greys unless a Link is selected. Pressing a greyed key just dismisses the panel without doing anything.
+
+The panel honours your keyboard layout: on AZERTY the `Q` cell shows `A` (and pressing the physical A key fires it), on QWERTZ the `Z` cell shows `Y`, etc.
+
 ## Copy and Paste
 
 1. Select nodes and press `Ctrl+C` — input nodes (Read, Camera, etc.) are automatically converted to hidden-input proxies in the clipboard.
@@ -74,6 +91,7 @@ _Anchors_ differentiates between three "tiers" of anchors:
 | Shortcut | Action |
 |----------|--------|
 | `A` | Create anchor (node selected), open link picker (nothing selected), or rename anchor (anchor selected) |
+| `Shift+A` | Leader Key — opens the command overlay (Q/W/E set B/A/Mask input, R sets first free, F/J/L/Z navigate, X reconnect, `,` prefs) |
 | `Alt+A` | Open anchor navigation picker — jump DAG to any anchor or labelled backdrop |
 | `Alt+J` | Jump to source anchor (Link selected) |
 | `Alt+L` | Cycle through Link nodes pointing at the selected anchor |

--- a/input_sets.py
+++ b/input_sets.py
@@ -32,8 +32,21 @@ def _selected_target_node():
 
     A link node is excluded so that pressing Q/W/E/R after creating a link
     (when the new link is now selected) does not re-target the link itself.
+
+    nuke.selectedNodes() is wrapped in a ``with nuke.lastHitGroup():`` block to
+    pick up the panel context (root vs an open Group panel) that was active
+    when the leader was armed — matches the pattern used by anchor_shortcut /
+    create_anchor / select_anchor_and_create.
     """
-    selected = nuke.selectedNodes()
+    try:
+        hit_group = nuke.lastHitGroup()
+    except Exception:
+        hit_group = None
+    if hit_group is not None:
+        with hit_group:
+            selected = nuke.selectedNodes()
+    else:
+        selected = nuke.selectedNodes()
     if len(selected) != 1:
         return None
     target = selected[0]

--- a/input_sets.py
+++ b/input_sets.py
@@ -1,0 +1,216 @@
+"""Set Input To... commands for issue #50.
+
+Each entry point opens the anchor picker, and on selection creates a link node
+above the currently-selected target node and wires it into a specific input
+slot:
+
+    set_input_to_b()              -> input 0
+    set_input_to_a()              -> input 1
+    set_input_to_mask()           -> the target node's mask input (resolved by
+                                     the >100-maxInputs heuristic, see
+                                     resolve_mask_input_index)
+    set_input_to_first_available() -> the lowest free input on the target node
+
+Q/W/E/mask replace whatever was previously wired to the target slot via
+nuke.Node.setInput.  R only fills empty slots so it never silently clobbers
+existing wiring.
+"""
+
+import nuke
+
+import anchor
+import prefs
+from link import is_link
+
+
+# ---------------------------------------------------------------------------
+# Selected-target helpers
+# ---------------------------------------------------------------------------
+
+def _selected_target_node():
+    """Return the single selected non-link node, or None.
+
+    A link node is excluded so that pressing Q/W/E/R after creating a link
+    (when the new link is now selected) does not re-target the link itself.
+    """
+    selected = nuke.selectedNodes()
+    if len(selected) != 1:
+        return None
+    target = selected[0]
+    if is_link(target):
+        return None
+    return target
+
+
+def resolve_mask_input_index(target_node):
+    """Return the input index to treat as the mask input for *target_node*, or None.
+
+    Heuristic (per the locked plan):
+      - If maxInputs() > 100 (e.g. Merge2, Dissolve, Switch) -> input 2.
+      - Otherwise -> the last input slot (maxInputs() - 1).
+      - Single-input nodes (maxInputs() <= 1) have no mask input -> None.
+    """
+    try:
+        max_inputs = target_node.maxInputs()
+    except (AttributeError, TypeError):
+        return None
+    if max_inputs is None or max_inputs <= 1:
+        return None
+    if max_inputs > 100:
+        return 2
+    return max_inputs - 1
+
+
+def _first_free_input_index(target_node):
+    """Return the lowest input index on *target_node* that is currently empty, or None.
+
+    Walks 0..maxInputs()-1 and returns the first slot whose input(i) is None.
+    Returns None if every slot is filled.
+    """
+    try:
+        max_inputs = target_node.maxInputs()
+    except (AttributeError, TypeError):
+        return None
+    if max_inputs is None or max_inputs <= 0:
+        return None
+    for input_index in range(max_inputs):
+        if target_node.input(input_index) is None:
+            return input_index
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Predicates used by leader_overlay to grey-out unavailable bindings.
+# ---------------------------------------------------------------------------
+
+def can_set_input_b(target_node):
+    """True when target has at least input 0."""
+    if target_node is None:
+        return False
+    try:
+        return target_node.maxInputs() >= 1
+    except (AttributeError, TypeError):
+        return False
+
+
+def can_set_input_a(target_node):
+    """True when target has at least input 1."""
+    if target_node is None:
+        return False
+    try:
+        return target_node.maxInputs() >= 2
+    except (AttributeError, TypeError):
+        return False
+
+
+def can_set_input_mask(target_node):
+    """True when target has more than 1 input (resolve_mask_input_index returns a slot)."""
+    if target_node is None:
+        return False
+    return resolve_mask_input_index(target_node) is not None
+
+
+def can_set_input_first_available(target_node):
+    """True when target has any free input slot."""
+    if target_node is None:
+        return False
+    return _first_free_input_index(target_node) is not None
+
+
+# ---------------------------------------------------------------------------
+# Link-creation helper shared by all four set_input_to_* entry points.
+# ---------------------------------------------------------------------------
+
+# Per-input horizontal offset between sibling links so they don't overlap when
+# multiple links feed the same multi-input target.  Input 0 sits centered above
+# the target; each subsequent input shifts the link 150px further right.
+_LINK_INPUT_X_OFFSET = 150
+
+
+def _position_link_for_input(link_node, target_node, input_index):
+    """Place *link_node* above *target_node*, offset by input_index * 150px."""
+    base_x = target_node.xpos() + target_node.screenWidth() // 2 - link_node.screenWidth() // 2
+    link_node.setXYpos(
+        base_x + input_index * _LINK_INPUT_X_OFFSET,
+        target_node.ypos() - link_node.screenHeight() - 40,
+    )
+
+
+def _create_link_above_target(anchor_node, target_node, input_index):
+    """Create a link to *anchor_node* and position it above *target_node*.
+
+    Returns the new link node.  Horizontal offset scales with input_index so
+    multiple links feeding the same target don't overlap.
+    """
+    link_node = anchor.create_from_anchor(anchor_node)
+    _position_link_for_input(link_node, target_node, input_index)
+    return link_node
+
+
+def _set_input_to_index(input_index):
+    """Open the picker; on selection, wire the new link to *input_index* on the target.
+
+    Silent no-op when no single target node is selected.  The picker itself
+    handles the "no anchors exist" case.
+    """
+    if not prefs.plugin_enabled:
+        return
+    target_node = _selected_target_node()
+    if target_node is None:
+        return
+
+    def _on_pick(anchor_node, hit_group):
+        with hit_group:
+            link_node = _create_link_above_target(anchor_node, target_node, input_index)
+            target_node.setInput(input_index, link_node)
+
+    anchor.pick_anchor(_on_pick)
+
+
+# ---------------------------------------------------------------------------
+# Public entry points — invoked by leader.py dispatch table.
+# ---------------------------------------------------------------------------
+
+def set_input_to_b():
+    """Open picker; wire new link into target's input 0 (the B slot on Merge)."""
+    _set_input_to_index(0)
+
+
+def set_input_to_a():
+    """Open picker; wire new link into target's input 1 (the A slot on Merge)."""
+    _set_input_to_index(1)
+
+
+def set_input_to_mask():
+    """Open picker; wire new link into target's mask input.
+
+    Silent no-op when the target has no mask input
+    (resolve_mask_input_index returns None).
+    """
+    if not prefs.plugin_enabled:
+        return
+    target_node = _selected_target_node()
+    if target_node is None:
+        return
+    mask_index = resolve_mask_input_index(target_node)
+    if mask_index is None:
+        return
+    _set_input_to_index(mask_index)
+
+
+def set_input_to_first_available():
+    """Open picker; wire new link into the lowest-index free input on the target.
+
+    Silent no-op when every slot is already filled.
+    """
+    if not prefs.plugin_enabled:
+        return
+    target_node = _selected_target_node()
+    if target_node is None:
+        return
+    free_index = _first_free_input_index(target_node)
+    if free_index is None:
+        return
+    _set_input_to_index(free_index)
+
+

--- a/leader.py
+++ b/leader.py
@@ -105,39 +105,37 @@ def _dispatch_open_prefs():
 #
 # We bind by *physical key position*, not by produced letter.  Without a remap,
 # pressing the top-left letter on an AZERTY keyboard (which types 'A') would
-# fail to trigger the Q binding.  We detect the user's layout via QLocale and
-# rewrite Qt.Key codes accordingly so the user's muscle memory works regardless
-# of layout.
+# fail to trigger the Q binding.  The active layout comes from the user's
+# preference (prefs.keyboard_layout); rebuild_layout() re-derives the remap
+# and dispatch tables when that pref changes.
 #
 # The mapping is QWERTY-canonical-letter → letter-physically-at-that-position.
 # Example: on AZERTY the top-left letter key is 'A', so Q → A.
 # ---------------------------------------------------------------------------
 
-def _build_layout_remap():
-    """Return a dict mapping QWERTY canonical letters to current-layout letters.
+_AZERTY_REMAP = {"Q": "A", "W": "Z", "A": "Q", "Z": "W"}
+_QWERTZ_REMAP = {"Y": "Z", "Z": "Y"}
+_REMAPS_BY_LAYOUT = {
+    "qwerty": {},
+    "azerty": _AZERTY_REMAP,
+    "qwertz": _QWERTZ_REMAP,
+}
 
-    Heuristic based on system locale.  Returns {} (identity / QWERTY) for
-    unknown layouts or when QLocale is unavailable / mocked in tests.
+
+def _remap_from_prefs():
+    """Return the remap dict for the layout configured in prefs.
+
+    Returns {} (identity / QWERTY) for unknown values or when prefs is
+    unavailable (e.g. during isolated unit tests).
     """
     try:
-        from PySide6.QtCore import QLocale
-        locale_name = QLocale.system().name()
-        if not isinstance(locale_name, str):
-            return {}
-        lang, _, country = locale_name.partition("_")
-        # AZERTY: France and Belgium only.  Do NOT remap on lang == "fr" alone:
-        # fr_CA (Canadian French) ships QWERTY and would be wrongly mapped.
-        if country in ("FR", "BE"):
-            return {"Q": "A", "W": "Z", "A": "Q", "Z": "W"}
-        # QWERTZ: Germany, Austria, Switzerland, Czech, Slovak, Slovenian, Croatian
-        if country in ("DE", "AT", "CH") or lang in ("de", "cs", "sk", "sl", "hr"):
-            return {"Y": "Z", "Z": "Y"}
+        import prefs
+        return _REMAPS_BY_LAYOUT.get(prefs.keyboard_layout, {})
     except Exception:
-        pass
-    return {}
+        return {}
 
 
-LAYOUT_REMAP = _build_layout_remap()
+LAYOUT_REMAP = _remap_from_prefs()
 
 
 def _letter_to_qt_key(letter):
@@ -199,6 +197,28 @@ def _build_dispatch_tables():
 
 
 _DISPATCH_TABLE, _CHAINING_DISPATCH_TABLE, _QT_KEY_TO_LETTER = _build_dispatch_tables()
+
+
+def rebuild_layout():
+    """Re-derive LAYOUT_REMAP and dispatch tables from current prefs.
+
+    Called by PrefsDialog._on_accept() after the user changes the keyboard
+    layout pref, so the change applies live without a Nuke restart.
+
+    Also drops the cached overlay singleton so the next arm() rebuilds it
+    with cell labels reflecting the new layout — the overlay bakes its
+    glyphs at construction time, so an in-place update of dispatch tables
+    alone would leave stale labels on the panel.
+    """
+    global LAYOUT_REMAP, _DISPATCH_TABLE, _CHAINING_DISPATCH_TABLE, _QT_KEY_TO_LETTER, _overlay
+    LAYOUT_REMAP = _remap_from_prefs()
+    _DISPATCH_TABLE, _CHAINING_DISPATCH_TABLE, _QT_KEY_TO_LETTER = _build_dispatch_tables()
+    if _overlay is not None:
+        try:
+            _overlay.deleteLater()
+        except Exception:
+            pass
+        _overlay = None
 
 
 # ---------------------------------------------------------------------------

--- a/leader.py
+++ b/leader.py
@@ -125,8 +125,9 @@ def _build_layout_remap():
         if not isinstance(locale_name, str):
             return {}
         lang, _, country = locale_name.partition("_")
-        # AZERTY: France, Belgium
-        if country in ("FR", "BE") or lang == "fr":
+        # AZERTY: France and Belgium only.  Do NOT remap on lang == "fr" alone:
+        # fr_CA (Canadian French) ships QWERTY and would be wrongly mapped.
+        if country in ("FR", "BE"):
             return {"Q": "A", "W": "Z", "A": "Q", "Z": "W"}
         # QWERTZ: Germany, Austria, Switzerland, Czech, Slovak, Slovenian, Croatian
         if country in ("DE", "AT", "CH") or lang in ("de", "cs", "sk", "sl", "hr"):
@@ -155,45 +156,45 @@ def physical_letter_for(canonical_letter):
 
 
 # ---------------------------------------------------------------------------
-# Dispatch tables — split into single-shot and chaining.
-# Keyed by Qt.Key codes that the OS will actually deliver on the user's
-# layout (i.e. post-remap).
+# Dispatch tables — derived from constants.LEADER_BINDINGS, the single source
+# of truth.  Keyed by Qt.Key codes that the OS will actually deliver on the
+# user's layout (i.e. post-remap).  The kind field on each binding picks
+# single-shot vs chaining.
 # ---------------------------------------------------------------------------
 
-_DISPATCH_PAIRS = (
-    ('Q', _dispatch_set_input_to_b),
-    ('W', _dispatch_set_input_to_a),
-    ('E', _dispatch_set_input_to_mask),
-    ('R', _dispatch_set_input_first_available),
-    ('F', _dispatch_anchor_find),
-    ('J', _dispatch_anchor_jump),
-    ('Z', _dispatch_anchor_back),
-    ('X', _dispatch_reconnect_all_links),
-    (',', _dispatch_open_prefs),
-)
-
-_CHAINING_PAIRS = (
-    ('L', _dispatch_cycle_links),
-)
+_DISPATCH_BY_LETTER = {
+    'Q': _dispatch_set_input_to_b,
+    'W': _dispatch_set_input_to_a,
+    'E': _dispatch_set_input_to_mask,
+    'R': _dispatch_set_input_first_available,
+    'F': _dispatch_anchor_find,
+    'J': _dispatch_anchor_jump,
+    'L': _dispatch_cycle_links,
+    'Z': _dispatch_anchor_back,
+    'X': _dispatch_reconnect_all_links,
+    ',': _dispatch_open_prefs,
+}
 
 
 def _build_dispatch_tables():
     """Return (single, chaining, qt_to_letter) — all three Qt.Key-keyed."""
+    from constants import LEADER_BINDINGS
     single = {}
     chaining = {}
     qt_to_letter = {}
-    for canonical_letter, fn in _DISPATCH_PAIRS:
+    for canonical_letter, _label, _row, _col, kind in LEADER_BINDINGS:
+        fn = _DISPATCH_BY_LETTER.get(canonical_letter)
+        if fn is None:
+            continue
         physical = physical_letter_for(canonical_letter)
         qt_key = _letter_to_qt_key(physical)
-        if qt_key is not None:
-            single[qt_key] = fn
-            qt_to_letter[qt_key] = canonical_letter
-    for canonical_letter, fn in _CHAINING_PAIRS:
-        physical = physical_letter_for(canonical_letter)
-        qt_key = _letter_to_qt_key(physical)
-        if qt_key is not None:
+        if qt_key is None:
+            continue
+        if kind == 'chaining':
             chaining[qt_key] = fn
-            qt_to_letter[qt_key] = canonical_letter
+        else:
+            single[qt_key] = fn
+        qt_to_letter[qt_key] = canonical_letter
     return single, chaining, qt_to_letter
 
 
@@ -207,6 +208,27 @@ _DISPATCH_TABLE, _CHAINING_DISPATCH_TABLE, _QT_KEY_TO_LETTER = _build_dispatch_t
 # ---------------------------------------------------------------------------
 
 
+def _selected_nodes_in_hit_group():
+    """Return nuke.selectedNodes() picked up inside the active panel's group.
+
+    Wrapping the read in ``with nuke.lastHitGroup():`` matches the rest of the
+    codebase (anchor_shortcut, select_anchor_and_create, …) so floating Group
+    panels see their own selection rather than the root selection.
+    """
+    try:
+        import nuke
+    except Exception:
+        return []
+    try:
+        hit_group = nuke.lastHitGroup()
+    except Exception:
+        hit_group = None
+    if hit_group is not None:
+        with hit_group:
+            return nuke.selectedNodes()
+    return nuke.selectedNodes()
+
+
 def _selected_non_link_target():
     """Return the currently-selected single non-link node, or None.
 
@@ -214,9 +236,8 @@ def _selected_non_link_target():
     input_sets receive exactly the same target the dispatchers will see.
     """
     try:
-        import nuke
         from link import is_link
-        selected = nuke.selectedNodes()
+        selected = _selected_nodes_in_hit_group()
         if len(selected) != 1:
             return None
         if is_link(selected[0]):
@@ -229,8 +250,7 @@ def _selected_non_link_target():
 def _selected_single_node():
     """Return the only selected node (of any kind), or None."""
     try:
-        import nuke
-        selected = nuke.selectedNodes()
+        selected = _selected_nodes_in_hit_group()
         if len(selected) == 1:
             return selected[0]
     except Exception:

--- a/leader.py
+++ b/leader.py
@@ -1,0 +1,484 @@
+"""Leader-key event filter and state machine for the anchors plugin.
+
+``arm()`` is the sole public entry point.  It is bound to Shift+A in menu.py
+with shortcutContext=2 (DAG-only focus) so this module never has to do its
+own focus check.
+
+Lifecycle
+---------
+1. The user presses Shift+A.
+2. ``arm()`` flips ``_leader_active`` to True, installs a single ``LeaderKeyFilter``
+   on QApplication, and schedules the overlay to appear after a brief delay.
+3. The next QKeyEvent is intercepted by the filter:
+     - A *single-shot* binding (Q, W, E, R, F, J, Z, X, comma) disarms first,
+       then dispatches.
+     - A *chaining* binding (L) hides the overlay, dispatches, and stays armed
+       for further chaining keys.
+     - Anything else (or a mouse click) disarms cleanly.
+
+The Win32 / Linux taskbar suppression code lives in leader_overlay.py — see
+the docstrings there for why those work-arounds were necessary.
+"""
+
+import contextlib
+
+from PySide6.QtCore import QEvent, QObject, Qt, QTimer
+from PySide6.QtWidgets import QApplication
+
+
+# ---------------------------------------------------------------------------
+# Module-level singletons / state
+# ---------------------------------------------------------------------------
+
+_leader_active = False
+_filter = None
+_overlay = None
+_overlay_timer = None
+
+# Set True around any programmatic _overlay.hide() call that should NOT disarm
+# leader mode (i.e. chaining hides).  hideEvent on the overlay reads this and
+# skips its _disarm() call when set.  Keeps click-outside disarms working
+# (those flow through hideEvent without this flag set).
+_suppress_disarm_on_hide = False
+
+# Delay before the overlay appears.  Short enough that touch-typists never
+# see it; long enough that fast Shift+A → key sequences never flash it.
+_OVERLAY_DELAY_MS = 200
+
+
+# ---------------------------------------------------------------------------
+# Dispatch helpers — inline imports keep startup cheap and avoid cycles.
+# ---------------------------------------------------------------------------
+
+def _dispatch_set_input_to_b():
+    import input_sets
+    input_sets.set_input_to_b()
+
+
+def _dispatch_set_input_to_a():
+    import input_sets
+    input_sets.set_input_to_a()
+
+
+def _dispatch_set_input_to_mask():
+    import input_sets
+    input_sets.set_input_to_mask()
+
+
+def _dispatch_set_input_first_available():
+    import input_sets
+    input_sets.set_input_to_first_available()
+
+
+def _dispatch_anchor_find():
+    import anchor
+    anchor.select_anchor_and_navigate()
+
+
+def _dispatch_anchor_jump():
+    import anchor
+    anchor.jump_to_selected_anchor()
+
+
+def _dispatch_cycle_links():
+    import anchor
+    anchor.cycle_next_link()
+
+
+def _dispatch_anchor_back():
+    import anchor
+    anchor.navigate_back()
+
+
+def _dispatch_reconnect_all_links():
+    import anchor
+    anchor.reconnect_all_links()
+
+
+def _dispatch_open_prefs():
+    from colors import PrefsDialog
+    PrefsDialog().exec()
+
+
+# ---------------------------------------------------------------------------
+# Keyboard-layout remap.
+#
+# We bind by *physical key position*, not by produced letter.  Without a remap,
+# pressing the top-left letter on an AZERTY keyboard (which types 'A') would
+# fail to trigger the Q binding.  We detect the user's layout via QLocale and
+# rewrite Qt.Key codes accordingly so the user's muscle memory works regardless
+# of layout.
+#
+# The mapping is QWERTY-canonical-letter → letter-physically-at-that-position.
+# Example: on AZERTY the top-left letter key is 'A', so Q → A.
+# ---------------------------------------------------------------------------
+
+def _build_layout_remap():
+    """Return a dict mapping QWERTY canonical letters to current-layout letters.
+
+    Heuristic based on system locale.  Returns {} (identity / QWERTY) for
+    unknown layouts or when QLocale is unavailable / mocked in tests.
+    """
+    try:
+        from PySide6.QtCore import QLocale
+        locale_name = QLocale.system().name()
+        if not isinstance(locale_name, str):
+            return {}
+        lang, _, country = locale_name.partition("_")
+        # AZERTY: France, Belgium
+        if country in ("FR", "BE") or lang == "fr":
+            return {"Q": "A", "W": "Z", "A": "Q", "Z": "W"}
+        # QWERTZ: Germany, Austria, Switzerland, Czech, Slovak, Slovenian, Croatian
+        if country in ("DE", "AT", "CH") or lang in ("de", "cs", "sk", "sl", "hr"):
+            return {"Y": "Z", "Z": "Y"}
+    except Exception:
+        pass
+    return {}
+
+
+LAYOUT_REMAP = _build_layout_remap()
+
+
+def _letter_to_qt_key(letter):
+    if letter == ',':
+        return Qt.Key.Key_Comma
+    return getattr(Qt.Key, f'Key_{letter}', None)
+
+
+def physical_letter_for(canonical_letter):
+    """Return the letter the user physically types to invoke the *canonical_letter* binding.
+
+    Public so leader_overlay.py can render the right glyph on each cell.
+    Comma and any unmapped letter pass through unchanged.
+    """
+    return LAYOUT_REMAP.get(canonical_letter, canonical_letter)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tables — split into single-shot and chaining.
+# Keyed by Qt.Key codes that the OS will actually deliver on the user's
+# layout (i.e. post-remap).
+# ---------------------------------------------------------------------------
+
+_DISPATCH_PAIRS = (
+    ('Q', _dispatch_set_input_to_b),
+    ('W', _dispatch_set_input_to_a),
+    ('E', _dispatch_set_input_to_mask),
+    ('R', _dispatch_set_input_first_available),
+    ('F', _dispatch_anchor_find),
+    ('J', _dispatch_anchor_jump),
+    ('Z', _dispatch_anchor_back),
+    ('X', _dispatch_reconnect_all_links),
+    (',', _dispatch_open_prefs),
+)
+
+_CHAINING_PAIRS = (
+    ('L', _dispatch_cycle_links),
+)
+
+
+def _build_dispatch_tables():
+    """Return (single, chaining, qt_to_letter) — all three Qt.Key-keyed."""
+    single = {}
+    chaining = {}
+    qt_to_letter = {}
+    for canonical_letter, fn in _DISPATCH_PAIRS:
+        physical = physical_letter_for(canonical_letter)
+        qt_key = _letter_to_qt_key(physical)
+        if qt_key is not None:
+            single[qt_key] = fn
+            qt_to_letter[qt_key] = canonical_letter
+    for canonical_letter, fn in _CHAINING_PAIRS:
+        physical = physical_letter_for(canonical_letter)
+        qt_key = _letter_to_qt_key(physical)
+        if qt_key is not None:
+            chaining[qt_key] = fn
+            qt_to_letter[qt_key] = canonical_letter
+    return single, chaining, qt_to_letter
+
+
+_DISPATCH_TABLE, _CHAINING_DISPATCH_TABLE, _QT_KEY_TO_LETTER = _build_dispatch_tables()
+
+
+# ---------------------------------------------------------------------------
+# Per-binding enable check.
+# Used by both the event filter / dispatch_key (to ignore presses on greyed
+# bindings) and leader_overlay.refresh_for_selection (to grey them visually).
+# ---------------------------------------------------------------------------
+
+
+def _selected_non_link_target():
+    """Return the currently-selected single non-link node, or None.
+
+    Mirrors input_sets._selected_target_node so the enable predicates in
+    input_sets receive exactly the same target the dispatchers will see.
+    """
+    try:
+        import nuke
+        from link import is_link
+        selected = nuke.selectedNodes()
+        if len(selected) != 1:
+            return None
+        if is_link(selected[0]):
+            return None
+        return selected[0]
+    except Exception:
+        return None
+
+
+def _selected_single_node():
+    """Return the only selected node (of any kind), or None."""
+    try:
+        import nuke
+        selected = nuke.selectedNodes()
+        if len(selected) == 1:
+            return selected[0]
+    except Exception:
+        pass
+    return None
+
+
+def _is_binding_enabled(letter):
+    """Return True if pressing *letter* should fire its dispatcher right now.
+
+    Single source of truth for both:
+      - dispatch gating (event filter and dispatch_key use this to silently
+        disarm when the user presses a greyed key — no surprise wiring)
+      - the overlay's grey-out (refresh_for_selection consults this)
+
+    Comma (Preferences) is always enabled, even when the plugin is disabled,
+    so the user can re-enable from the dialog.  All other anchor commands
+    require prefs.plugin_enabled.
+    """
+    if letter == ',':
+        return True
+
+    import prefs
+    if not prefs.plugin_enabled:
+        return False
+
+    if letter in ('Q', 'W', 'E', 'R'):
+        import input_sets
+        target_node = _selected_non_link_target()
+        if letter == 'Q':
+            return input_sets.can_set_input_b(target_node)
+        if letter == 'W':
+            return input_sets.can_set_input_a(target_node)
+        if letter == 'E':
+            return input_sets.can_set_input_mask(target_node)
+        if letter == 'R':
+            return input_sets.can_set_input_first_available(target_node)
+
+    if letter == 'J':
+        # Anchor Jump goes from a Link node up to its source anchor.
+        from link import is_link
+        node = _selected_single_node()
+        return node is not None and is_link(node)
+
+    if letter == 'L':
+        # Cycle Links steps through links of the selected anchor.
+        from link import is_anchor
+        node = _selected_single_node()
+        return node is not None and is_anchor(node)
+
+    if letter == 'Z':
+        # Navigate-back is only meaningful when a back position has been saved.
+        import anchor
+        return anchor._back_position is not None
+
+    # F / X — always available when the plugin is enabled.
+    return True
+
+
+# ---------------------------------------------------------------------------
+# LeaderKeyFilter — Qt event filter installed on QApplication during leader mode.
+# ---------------------------------------------------------------------------
+
+class LeaderKeyFilter(QObject):
+    """Intercepts key/mouse events while leader mode is armed.
+
+    ShortcutOverride is consumed first — otherwise Nuke's own shortcut system
+    matches single keys (e.g. ``F`` → fullscreen) before our KeyPress handler
+    runs.  This is the load-bearing trick that makes the leader work at all.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # Named timer instance so _disarm() can stop it.  QTimer.singleShot()
+        # returns None and cannot be cancelled.
+        self._overlay_timer = QTimer()
+        self._overlay_timer.setSingleShot(True)
+        global _overlay_timer
+        _overlay_timer = self._overlay_timer
+
+    def eventFilter(self, watched, event):  # noqa: N802 — Qt naming
+        global _leader_active
+        if not _leader_active:
+            return False
+
+        event_type = event.type()
+
+        if event_type == QEvent.Type.ShortcutOverride:
+            event.accept()
+            return True
+
+        if event_type == QEvent.Type.KeyPress:
+            if event.isAutoRepeat():
+                return True
+
+            key = event.key()
+
+            # Recognise the key against the bindings table; gate on enable
+            # state so a greyed binding (e.g. W on a single-input node) silently
+            # disarms instead of firing the wrong wiring.
+            letter = _QT_KEY_TO_LETTER.get(key)
+            if letter is None or not _is_binding_enabled(letter):
+                _disarm()
+                return True
+
+            chaining_function = _CHAINING_DISPATCH_TABLE.get(key)
+            if chaining_function is not None:
+                _hide_overlay_for_chaining()
+                chaining_function()
+                return True
+
+            dispatch_function = _DISPATCH_TABLE.get(key)
+            if dispatch_function is not None:
+                _disarm()
+                dispatch_function()
+                return True
+
+            # Recognised but with no dispatcher — should not happen given the
+            # _QT_KEY_TO_LETTER → enable-check gate above.
+            _disarm()
+            return True
+
+        if event_type == QEvent.Type.MouseButtonPress:
+            # Click during leader mode: disarm but let the click propagate so
+            # the user's intended click still fires.
+            _disarm()
+            return False
+
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public entry point + internal helpers
+# ---------------------------------------------------------------------------
+
+def arm():
+    """Activate leader-key mode.
+
+    Idempotent — re-arming while already armed is a no-op.  Lazily creates
+    the filter and overlay singletons on first call.
+    """
+    global _leader_active, _filter, _overlay
+
+    if _leader_active:
+        return
+
+    if _filter is None:
+        _filter = LeaderKeyFilter()
+
+    # Lazy-import the overlay so importing leader.py doesn't drag in the full
+    # Qt widget hierarchy at Nuke startup (when init.py runs menu.py).
+    if _overlay is None:
+        try:
+            from leader_overlay import LeaderKeyOverlay
+            _overlay = LeaderKeyOverlay()
+        except Exception:
+            # Overlay creation must never block leader mode itself.
+            _overlay = None
+
+    _leader_active = True
+    QApplication.instance().installEventFilter(_filter)
+
+    if _overlay is not None and _overlay_timer is not None:
+        with contextlib.suppress(RuntimeError):
+            _overlay_timer.timeout.disconnect()
+        _overlay_timer.timeout.connect(_show_overlay)
+        _overlay_timer.start(_OVERLAY_DELAY_MS)
+
+
+def _show_overlay():
+    """Refresh the overlay's per-key enable/disable state and show it."""
+    if _overlay is None:
+        return
+    try:
+        _overlay.refresh_for_selection()
+    except AttributeError:
+        pass
+    _overlay.show()
+
+
+def _disarm():
+    """Deactivate leader-key mode and tear everything down.
+
+    Safe to call from inside eventFilter — Qt explicitly allows
+    removeEventFilter during event delivery.
+    """
+    global _leader_active
+    if not _leader_active:
+        return
+    _leader_active = False
+    app = QApplication.instance()
+    if app is not None and _filter is not None:
+        app.removeEventFilter(_filter)
+    if _overlay_timer is not None:
+        _overlay_timer.stop()
+    if _overlay is not None:
+        _overlay.hide()
+
+
+def _hide_overlay_for_chaining():
+    """Hide the overlay during a chaining dispatch without disarming.
+
+    Sets _suppress_disarm_on_hide so the overlay's hideEvent skips its
+    _disarm() call (the click-outside auto-close path still disarms because
+    that path doesn't go through here).  Also stops the show timer so a
+    pending overlay show after this hide doesn't pop the overlay back up
+    while the user is still chaining.
+    """
+    global _suppress_disarm_on_hide
+    if _overlay_timer is not None:
+        _overlay_timer.stop()
+    if _overlay is None:
+        return
+    _suppress_disarm_on_hide = True
+    try:
+        _overlay.hide()
+    finally:
+        _suppress_disarm_on_hide = False
+
+
+def dispatch_key(canonical_letter):
+    """Dispatch as if the user pressed the binding for *canonical_letter*.
+
+    Used by overlay click cells, which always pass the canonical (QWERTY) letter
+    so the same dispatcher runs regardless of layout.  Mirrors the eventFilter
+    routing — single-shot keys disarm first, chaining keys hide the overlay
+    and stay armed.
+    """
+    canonical_letter = canonical_letter if canonical_letter == ',' else canonical_letter.upper()
+    physical_letter = physical_letter_for(canonical_letter)
+    qt_key = _letter_to_qt_key(physical_letter)
+    if qt_key is None:
+        return
+
+    # Same enable gate as the keyboard path.  Greyed cells are still clickable
+    # because Qt routes mousePressEvent through here regardless; refuse to
+    # dispatch when the binding is disabled.
+    if not _is_binding_enabled(canonical_letter):
+        _disarm()
+        return
+
+    chaining_function = _CHAINING_DISPATCH_TABLE.get(qt_key)
+    if chaining_function is not None:
+        _hide_overlay_for_chaining()
+        chaining_function()
+        return
+
+    dispatch_function = _DISPATCH_TABLE.get(qt_key)
+    if dispatch_function is not None:
+        _disarm()
+        dispatch_function()

--- a/leader_overlay.py
+++ b/leader_overlay.py
@@ -22,8 +22,6 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-import nuke
-
 from constants import LEADER_BINDINGS
 
 
@@ -186,8 +184,9 @@ class ClickableKeyCell(QWidget):
             self._action_text_label.setStyleSheet("color: #888888; background-color: transparent;")
 
     def mousePressEvent(self, event):  # noqa: N802 — Qt naming
-        if not self._enabled:
-            return
+        # leader.dispatch_key already gates on _is_binding_enabled and disarms
+        # silently when the binding is disabled, so we forward every click
+        # (greyed cells included) and let the dispatcher decide.
         import leader
         leader.dispatch_key(self._canonical_letter)
 

--- a/leader_overlay.py
+++ b/leader_overlay.py
@@ -1,0 +1,347 @@
+"""Floating HUD that lists active leader-mode bindings for the anchors plugin.
+
+Ported from node_layout's overlay; the Win32 ctypes and Linux X11 hint
+work-arounds are preserved verbatim because they were the difference
+between a usable HUD and a flashing taskbar (see node_layout 260331-axc).
+
+The bindings come from constants.LEADER_BINDINGS so this module and leader.py
+share a single source of truth.
+"""
+
+import sys
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QCursor, QFont, QGuiApplication, QPainter
+from PySide6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+import nuke
+
+from constants import LEADER_BINDINGS
+
+
+# ---------------------------------------------------------------------------
+# Platform-specific activation suppression.
+# Ported byte-for-byte from node_layout_overlay.py; see that file's header
+# comments for why these dance steps are necessary.
+# ---------------------------------------------------------------------------
+
+def _apply_no_activate_win32(hwnd):
+    """Set WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW on *hwnd* via raw Win32 API."""
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+
+        GWL_EXSTYLE = -20
+        WS_EX_NOACTIVATE = 0x08000000
+        WS_EX_TOOLWINDOW = 0x00000080
+        SWP_NOSIZE = 0x0001
+        SWP_NOMOVE = 0x0002
+        SWP_NOZORDER = 0x0004
+        SWP_NOACTIVATE = 0x0010
+        SWP_FRAMECHANGED = 0x0020
+
+        user32 = ctypes.windll.user32  # type: ignore[attr-defined]
+        current_ex_style = user32.GetWindowLongPtrW(hwnd, GWL_EXSTYLE)
+        new_ex_style = current_ex_style | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW
+        user32.SetWindowLongPtrW(hwnd, GWL_EXSTYLE, new_ex_style)
+        user32.SetWindowPos(
+            hwnd,
+            0,
+            0, 0, 0, 0,
+            SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+        )
+    except Exception:
+        pass
+
+
+def _apply_linux_hints(widget):
+    """Set _NET_WM_STATE_SKIP_TASKBAR / _NET_WM_STATE_SKIP_PAGER on Linux."""
+    if not sys.platform.startswith("linux"):
+        return
+    try:
+        widget.setProperty("_NET_WM_STATE_SKIP_TASKBAR", True)
+        widget.setProperty("_NET_WM_STATE_SKIP_PAGER", True)
+    except Exception:
+        pass
+
+
+def _restore_nuke_focus(parent_widget):
+    """Re-activate the Nuke parent window after show on Windows."""
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+
+        from PySide6.QtWidgets import QApplication
+
+        focus_target = parent_widget
+        if focus_target is None:
+            focus_target = QApplication.activeWindow()
+        if focus_target is None:
+            return
+        target_hwnd = int(focus_target.winId())
+        ctypes.windll.user32.SetForegroundWindow(target_hwnd)  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Color palette
+# ---------------------------------------------------------------------------
+
+_INPUT_KEY_COLOR = QColor(60, 160, 80)        # Q W E R — set-input commands (green)
+_CHAINING_KEY_COLOR = QColor(40, 120, 160)    # L — teal (stays armed; chain repeat)
+_NEUTRAL_KEY_COLOR = QColor(220, 220, 220)    # F J Z X comma — neutral white
+_DISABLED_COLOR = QColor(70, 70, 70)          # greyed-out cells
+
+_INPUT_KEYS = frozenset({'Q', 'W', 'E', 'R'})
+_CHAINING_KEYS = frozenset({'L'})
+
+
+def _badge_color_for(letter):
+    if letter in _INPUT_KEYS:
+        return _INPUT_KEY_COLOR
+    if letter in _CHAINING_KEYS:
+        return _CHAINING_KEY_COLOR
+    return _NEUTRAL_KEY_COLOR
+
+
+def _rgb_string(color):
+    return f"rgb({color.red()}, {color.green()}, {color.blue()})"
+
+
+# ---------------------------------------------------------------------------
+# Clickable key cell — keyboard and mouse share the dispatch path.
+# ---------------------------------------------------------------------------
+
+class ClickableKeyCell(QWidget):
+    """Square key badge that dispatches the same action as pressing the key.
+
+    *canonical_letter* is the QWERTY-canonical letter the binding is registered
+    under (used for dispatch and for the badge-color heuristic so colours stay
+    stable across layouts).  *display_letter* is what's actually printed on the
+    user's physical key for the current keyboard layout.
+    """
+
+    def __init__(self, canonical_letter, display_letter, action_label, parent=None):
+        super().__init__(parent)
+        self._canonical_letter = canonical_letter
+        self._enabled = True
+
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+
+        self._badge_frame = QFrame()
+        self._badge_frame.setFixedSize(70, 70)
+
+        badge_inner_layout = QVBoxLayout(self._badge_frame)
+        badge_inner_layout.setContentsMargins(3, 6, 3, 4)
+        badge_inner_layout.setSpacing(2)
+
+        self._key_letter_label = QLabel(display_letter)
+        self._key_letter_label.setFont(QFont("monospace", 14, QFont.Weight.Bold))
+        self._key_letter_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._key_letter_label.setStyleSheet("color: #111111; background-color: transparent;")
+
+        self._action_text_label = QLabel(action_label)
+        action_text_font = QFont()
+        action_text_font.setPointSize(7)
+        self._action_text_label.setFont(action_text_font)
+        self._action_text_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._action_text_label.setWordWrap(True)
+        self._action_text_label.setStyleSheet("color: #2a2a2a; background-color: transparent;")
+
+        badge_inner_layout.addWidget(self._key_letter_label)
+        badge_inner_layout.addWidget(self._action_text_label)
+
+        cell_layout = QVBoxLayout(self)
+        cell_layout.setContentsMargins(0, 0, 0, 0)
+        cell_layout.addWidget(self._badge_frame)
+
+        self._apply_color(_badge_color_for(canonical_letter))
+
+    def _apply_color(self, color):
+        self._badge_frame.setStyleSheet(
+            f"QFrame {{ background-color: {_rgb_string(color)}; border-radius: 6px; }}"
+        )
+
+    def set_enabled_visual(self, enabled):
+        """Visually grey the cell when *enabled* is False; restore otherwise."""
+        self._enabled = enabled
+        if enabled:
+            self._apply_color(_badge_color_for(self._canonical_letter))
+            self._key_letter_label.setStyleSheet("color: #111111; background-color: transparent;")
+            self._action_text_label.setStyleSheet("color: #2a2a2a; background-color: transparent;")
+        else:
+            self._apply_color(_DISABLED_COLOR)
+            self._key_letter_label.setStyleSheet("color: #aaaaaa; background-color: transparent;")
+            self._action_text_label.setStyleSheet("color: #888888; background-color: transparent;")
+
+    def mousePressEvent(self, event):  # noqa: N802 — Qt naming
+        if not self._enabled:
+            return
+        import leader
+        leader.dispatch_key(self._canonical_letter)
+
+
+# ---------------------------------------------------------------------------
+# Overlay dialog — Popup-flagged, frameless, non-activating.
+# ---------------------------------------------------------------------------
+
+class LeaderKeyOverlay(QDialog):
+    """Floating HUD; show()/hide() driven by leader.arm()/_disarm()."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowFlags(
+            Qt.WindowType.Popup
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowDoesNotAcceptFocus
+        )
+        self.setModal(False)
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        self._cells_by_letter = {}
+        self._build_ui()
+        self.adjustSize()
+        _apply_linux_hints(self)
+
+    def _build_ui(self):
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(16, 12, 16, 16)
+        main_layout.setSpacing(10)
+
+        title_label = QLabel("ANCHORS LEADER")
+        title_font = QFont()
+        title_font.setBold(True)
+        title_font.setPointSize(11)
+        title_label.setFont(title_font)
+        title_label.setStyleSheet("color: #cccccc;")
+        title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        main_layout.addWidget(title_label)
+
+        content_layout = QHBoxLayout()
+        content_layout.setSpacing(16)
+
+        # leader.physical_letter_for() honours the user's keyboard layout (AZERTY,
+        # QWERTZ, …), so cells display the letter that's actually printed on the
+        # user's physical key while still dispatching by canonical (QWERTY) name.
+        import leader
+
+        key_grid = QGridLayout()
+        key_grid.setSpacing(8)
+
+        for canonical_letter, action_label, row, col, _kind in LEADER_BINDINGS:
+            display_letter = leader.physical_letter_for(canonical_letter)
+            cell = ClickableKeyCell(canonical_letter, display_letter, action_label)
+            self._cells_by_letter[canonical_letter] = cell
+            key_grid.addWidget(cell, row, col)
+
+        content_layout.addLayout(key_grid)
+
+        sidebar_widget = QWidget()
+        sidebar_layout = QVBoxLayout(sidebar_widget)
+        sidebar_layout.setContentsMargins(0, 0, 0, 0)
+        sidebar_layout.setSpacing(4)
+
+        sidebar_title = QLabel("KEYS")
+        sidebar_title_font = QFont()
+        sidebar_title_font.setBold(True)
+        sidebar_title_font.setPointSize(8)
+        sidebar_title.setFont(sidebar_title_font)
+        sidebar_title.setStyleSheet("color: #888888;")
+        sidebar_layout.addWidget(sidebar_title)
+
+        for canonical_letter, action_label, _row, _col, _kind in LEADER_BINDINGS:
+            display_letter = leader.physical_letter_for(canonical_letter)
+            color = _badge_color_for(canonical_letter)
+            sidebar_row_label = QLabel(
+                f'<span style="color: {_rgb_string(color)}; font-weight: bold;">[{display_letter}]</span>'
+                f'<span style="color: #aaaaaa;"> {action_label}</span>'
+            )
+            sidebar_row_label.setTextFormat(Qt.TextFormat.RichText)
+            sidebar_row_font = QFont()
+            sidebar_row_font.setPointSize(8)
+            sidebar_row_label.setFont(sidebar_row_font)
+            sidebar_layout.addWidget(sidebar_row_label)
+
+        sidebar_layout.addStretch()
+        content_layout.addWidget(sidebar_widget)
+
+        main_layout.addLayout(content_layout)
+        self.setLayout(main_layout)
+
+    # -----------------------------------------------------------------------
+    # Per-binding enable/disable based on selection + plugin state
+    # -----------------------------------------------------------------------
+
+    def refresh_for_selection(self):
+        """Update each cell's enabled state based on the current selection.
+
+        Delegates to leader._is_binding_enabled so the overlay grey-out and the
+        actual dispatch gating share one source of truth.
+        """
+        import leader
+        for letter, cell in self._cells_by_letter.items():
+            cell.set_enabled_visual(leader._is_binding_enabled(letter))
+
+    # -----------------------------------------------------------------------
+    # Window plumbing
+    # -----------------------------------------------------------------------
+
+    def paintEvent(self, event):  # noqa: N802 — Qt naming
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setBrush(QColor(20, 20, 20, 180))
+        painter.setPen(QColor(180, 180, 180, 100))
+        painter.drawRoundedRect(self.rect(), 8, 8)
+
+    def show(self):
+        cursor_pos = QCursor.pos()
+        screen = QGuiApplication.screenAt(cursor_pos)
+        if screen is None:
+            screen = QGuiApplication.primaryScreen()
+        screen_geometry = screen.availableGeometry()
+
+        x = cursor_pos.x() - self.width() // 2
+        y = cursor_pos.y() - self.height() // 2
+
+        x = max(screen_geometry.left(), min(x, screen_geometry.right() - self.width()))
+        y = max(screen_geometry.top(), min(y, screen_geometry.bottom() - self.height()))
+
+        if sys.platform.startswith("linux"):
+            self.setGeometry(x, y, self.width(), self.height())
+        else:
+            self.move(x, y)
+        super().show()
+
+    def hideEvent(self, event):  # noqa: N802 — Qt naming
+        super().hideEvent(event)
+        # Click-outside auto-closes a Popup-flagged dialog.  Route those hides
+        # through _disarm() so leader state stays coherent.  Skip when the
+        # leader module is hiding the overlay deliberately as part of a
+        # chaining dispatch — that flag is set/unset around _overlay.hide() in
+        # _hide_overlay_for_chaining().
+        try:
+            import leader
+            if leader._suppress_disarm_on_hide:
+                return
+            leader._disarm()
+        except Exception:
+            pass
+
+    def showEvent(self, event):  # noqa: N802 — Qt naming
+        super().showEvent(event)
+        if sys.platform == "win32":
+            _apply_no_activate_win32(int(self.winId()))
+            _restore_nuke_focus(self.parent())

--- a/menu.py
+++ b/menu.py
@@ -48,6 +48,7 @@ _add_gated_command(anchors_menu, "Create Anchor",       "anchor.create_anchor()"
 _add_gated_command(anchors_menu, "Rename Anchor",       "anchor.rename_selected_anchor()")
 _add_gated_command(anchors_menu, "Create Link",                "anchor.select_anchor_and_create()")
 _add_gated_command(anchors_menu, "Anchor",              "anchor.anchor_shortcut()",            "A")
+_add_gated_command(anchors_menu, "Leader Key",          "import leader; leader.arm()",         "+A")
 _add_gated_command(anchors_menu, "Reconnect All Links", "anchor.reconnect_all_links()")
 _add_gated_command(anchors_menu, "Anchor Find", "anchor.select_anchor_and_navigate()", "alt+A")
 _add_gated_command(anchors_menu, "Anchor Jump", "anchor.jump_to_selected_anchor()", "alt+J")

--- a/menu.py
+++ b/menu.py
@@ -34,12 +34,14 @@ anchors_menu = edit_menu.addMenu("Anchors")
 _gated_menu_items = []
 
 
-def _add_gated_command(menu, name, command, shortcut=None):
+def _add_gated_command(menu, name, command, shortcut=None, shortcut_context=None):
     """Register a menu command and track its item reference for enable/disable."""
+    kwargs = {}
     if shortcut is not None:
-        item = menu.addCommand(name, command, shortcut)
-    else:
-        item = menu.addCommand(name, command)
+        kwargs['shortcut'] = shortcut
+    if shortcut_context is not None:
+        kwargs['shortcutContext'] = shortcut_context
+    item = menu.addCommand(name, command, **kwargs)
     if item is not None:
         _gated_menu_items.append(item)
 
@@ -48,7 +50,8 @@ _add_gated_command(anchors_menu, "Create Anchor",       "anchor.create_anchor()"
 _add_gated_command(anchors_menu, "Rename Anchor",       "anchor.rename_selected_anchor()")
 _add_gated_command(anchors_menu, "Create Link",                "anchor.select_anchor_and_create()")
 _add_gated_command(anchors_menu, "Anchor",              "anchor.anchor_shortcut()",            "A")
-_add_gated_command(anchors_menu, "Leader Key",          "import leader; leader.arm()",         "+A")
+_add_gated_command(anchors_menu, "Leader Key",          "import leader; leader.arm()",         "+A",
+                   shortcut_context=2)
 _add_gated_command(anchors_menu, "Reconnect All Links", "anchor.reconnect_all_links()")
 _add_gated_command(anchors_menu, "Anchor Find", "anchor.select_anchor_and_navigate()", "alt+A")
 _add_gated_command(anchors_menu, "Anchor Jump", "anchor.jump_to_selected_anchor()", "alt+J")

--- a/prefs.py
+++ b/prefs.py
@@ -23,6 +23,9 @@ naming_template = ""
 naming_demo_filename = "plate_v003.exr"
 site_config_override = False    # persisted to anchors_prefs.json
 last_publish_path = ""          # most recently chosen publish destination; persisted to anchors_prefs.json
+keyboard_layout = "qwerty"      # one of "qwerty", "azerty", "qwertz"; persisted to anchors_prefs.json
+
+_VALID_KEYBOARD_LAYOUTS = ("qwerty", "azerty", "qwertz")
 
 # Private — populated by _load_site_config(), never written to user prefs file directly
 _site_config = {}               # keys: field names locked by site config; values: admin values
@@ -61,6 +64,7 @@ def _load():
     global plugin_enabled, custom_colors, \
            naming_regex, naming_template, naming_demo_filename, \
            site_config_override, last_publish_path, \
+           keyboard_layout, \
            _user_naming_regex, _user_naming_template, \
            _user_naming_demo_filename
     if not os.path.exists(PREFS_PATH):
@@ -90,6 +94,8 @@ def _load():
             site_config_override = data['site_config_override']
         if isinstance(data.get('last_publish_path'), str):
             last_publish_path = data['last_publish_path']
+        if data.get('keyboard_layout') in _VALID_KEYBOARD_LAYOUTS:
+            keyboard_layout = data['keyboard_layout']
     except (OSError, ValueError, json.JSONDecodeError):
         pass  # silent fallback — module-level defaults remain
     # Copy user values into shadow vars before site config is applied
@@ -156,6 +162,7 @@ def save():
                 'naming_demo_filename': _user_naming_demo_filename,
                 'site_config_override': site_config_override,
                 'last_publish_path': last_publish_path,
+                'keyboard_layout': keyboard_layout,
             },
             file_handle,
         )

--- a/tests/test_input_sets.py
+++ b/tests/test_input_sets.py
@@ -1,0 +1,254 @@
+"""Tests for input_sets.py — Set B/A/Mask/First-Free Input To...
+
+Scope:
+  - Mask-input resolution heuristic (>100 maxInputs -> 2; else last input).
+  - First-free-input lookup.
+  - End-to-end set_input_to_b / a / mask / first_available with picker stubbed.
+  - Q/W/E replace whatever was previously wired; R only fills empty slots.
+  - Per-input horizontal offset so sibling links don't overlap.
+
+The picker (anchor.pick_anchor) is patched to invoke the on_pick callback
+synchronously with a stub anchor node, so tests exercise the wire-up path
+without spinning up Qt or tabtabtab.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tests.stubs import StubKnob, StubNode, make_stub_nuke_module
+
+if 'nuke' not in sys.modules:
+    sys.modules['nuke'] = make_stub_nuke_module()
+
+import input_sets
+
+
+def _make_target_node(node_class='Merge2', max_inputs=3, inputs=None, name=None):
+    """Return a StubNode that mimics a Merge-style multi-input node.
+
+    *inputs* is an optional list of length max_inputs; entries are the live
+    input nodes for each slot (None means empty).
+    """
+    target_name = name or f'{node_class}1'
+    target = StubNode(name=target_name, node_class=node_class)
+    target.maxInputs = lambda: max_inputs
+    target._inputs = list(inputs) if inputs is not None else [None] * max_inputs
+
+    def _input(index):
+        if 0 <= index < len(target._inputs):
+            return target._inputs[index]
+        return None
+
+    def _set_input(index, node):
+        while len(target._inputs) <= index:
+            target._inputs.append(None)
+        target._inputs[index] = node
+
+    target.input = _input
+    target.setInput = _set_input
+    return target
+
+
+def _make_anchor_node(name='Anchor_Foo'):
+    label_knob = StubKnob(value='Foo', knob_name='label')
+    return StubNode(name=name, node_class='NoOp', knobs_dict={'label': label_knob})
+
+
+def _make_link_node(name='LinkNode'):
+    """Stub link node that records setXYpos calls so tests can assert positioning."""
+    link = StubNode(name=name, node_class='NoOp')
+    # StubNode.setXYpos already records into _xpos/_ypos via setXYpos override.
+    # Append the (x, y) tuple to a history list so push-up repositioning can be checked.
+    link._xy_history = []
+    original_set_xypos = link.setXYpos
+
+    def _record_set_xypos(x, y):
+        link._xy_history.append((x, y))
+        original_set_xypos(x, y)
+
+    link.setXYpos = _record_set_xypos
+    return link
+
+
+class TestResolveMaskInputIndex(unittest.TestCase):
+    """Mask-input resolution: >100 maxInputs -> 2; else last input; <=1 -> None."""
+
+    def test_merge_uses_input_2(self):
+        target = _make_target_node(node_class='Merge2', max_inputs=999)
+        self.assertEqual(input_sets.resolve_mask_input_index(target), 2)
+
+    def test_two_input_node_uses_last(self):
+        target = _make_target_node(node_class='Keymix', max_inputs=3)
+        self.assertEqual(input_sets.resolve_mask_input_index(target), 2)
+
+    def test_blur_with_mask_uses_last(self):
+        target = _make_target_node(node_class='Blur', max_inputs=2)
+        self.assertEqual(input_sets.resolve_mask_input_index(target), 1)
+
+    def test_single_input_node_returns_none(self):
+        target = _make_target_node(node_class='Roto', max_inputs=1)
+        self.assertIsNone(input_sets.resolve_mask_input_index(target))
+
+    def test_zero_input_node_returns_none(self):
+        target = _make_target_node(node_class='Constant', max_inputs=0)
+        self.assertIsNone(input_sets.resolve_mask_input_index(target))
+
+
+class TestFirstFreeInputIndex(unittest.TestCase):
+    def test_returns_zero_when_all_empty(self):
+        target = _make_target_node(max_inputs=3, inputs=[None, None, None])
+        self.assertEqual(input_sets._first_free_input_index(target), 0)
+
+    def test_returns_first_gap(self):
+        existing = StubNode(name='X')
+        target = _make_target_node(max_inputs=3, inputs=[existing, None, None])
+        self.assertEqual(input_sets._first_free_input_index(target), 1)
+
+    def test_returns_none_when_full(self):
+        existing = StubNode(name='X')
+        target = _make_target_node(max_inputs=3, inputs=[existing, existing, existing])
+        self.assertIsNone(input_sets._first_free_input_index(target))
+
+
+class TestSetInputTo(unittest.TestCase):
+    """End-to-end Set Input To B/A/Mask/First-Free with picker stubbed."""
+
+    def setUp(self):
+        self._anchor_node = _make_anchor_node()
+        self._link_node = _make_link_node()
+
+        # The picker normally calls on_pick(anchor_node, hit_group) where
+        # hit_group is a Nuke group used as a context manager (`with hit_group:`).
+        # MagicMock supports the context-manager protocol natively.
+        self._fake_hit_group = MagicMock(name='hit_group')
+        self._pick_patcher = patch(
+            'input_sets.anchor.pick_anchor',
+            side_effect=lambda on_pick, hit_group=None: on_pick(
+                self._anchor_node, self._fake_hit_group
+            ),
+        )
+        self._pick_patcher.start()
+
+        # Patch create_from_anchor to return the stub link without touching nuke.
+        self._create_patcher = patch(
+            'input_sets.anchor.create_from_anchor',
+            return_value=self._link_node,
+        )
+        self._create_patcher.start()
+
+        # Plugin must be enabled for the entry points to do anything.
+        self._prefs_patcher = patch('input_sets.prefs.plugin_enabled', True)
+        self._prefs_patcher.start()
+
+    def tearDown(self):
+        self._pick_patcher.stop()
+        self._create_patcher.stop()
+        self._prefs_patcher.stop()
+
+    def _patch_selected(self, target):
+        """Patch nuke.selectedNodes() to return [target]."""
+        return patch('input_sets.nuke.selectedNodes', return_value=[target])
+
+    def test_set_input_to_b_wires_input_zero(self):
+        target = _make_target_node(max_inputs=3, inputs=[None, None, None])
+        with self._patch_selected(target):
+            input_sets.set_input_to_b()
+        self.assertIs(target.input(0), self._link_node)
+        self.assertIsNone(target.input(1))
+        self.assertIsNone(target.input(2))
+
+    def test_set_input_to_a_wires_input_one(self):
+        target = _make_target_node(max_inputs=3, inputs=[None, None, None])
+        with self._patch_selected(target):
+            input_sets.set_input_to_a()
+        self.assertIsNone(target.input(0))
+        self.assertIs(target.input(1), self._link_node)
+        self.assertIsNone(target.input(2))
+
+    def test_link_position_offset_scales_with_input_index(self):
+        """Each subsequent input shifts the link 150px to the right."""
+        target = _make_target_node(max_inputs=3, inputs=[None, None, None])
+        target._xpos = 0
+        target._ypos = 0
+        # _xy_history starts empty.
+        with self._patch_selected(target):
+            input_sets.set_input_to_b()
+        x_b = self._link_node._xy_history[-1][0]
+
+        # Reset the link node so set_input_to_a uses the same starting point.
+        self._link_node._xy_history.clear()
+        target._inputs = [None, None, None]
+        with self._patch_selected(target):
+            input_sets.set_input_to_a()
+        x_a = self._link_node._xy_history[-1][0]
+
+        self.assertEqual(x_a - x_b, 150)
+
+    def test_set_input_to_mask_uses_index_2_for_merge(self):
+        target = _make_target_node(node_class='Merge2', max_inputs=999, inputs=[None, None, None])
+        with self._patch_selected(target):
+            input_sets.set_input_to_mask()
+        self.assertIs(target.input(2), self._link_node)
+
+    def test_set_input_to_mask_uses_last_for_blur(self):
+        target = _make_target_node(node_class='Blur', max_inputs=2, inputs=[None, None])
+        with self._patch_selected(target):
+            input_sets.set_input_to_mask()
+        self.assertIs(target.input(1), self._link_node)
+
+    def test_set_input_to_mask_noop_for_single_input(self):
+        target = _make_target_node(node_class='Roto', max_inputs=1, inputs=[None])
+        with self._patch_selected(target):
+            input_sets.set_input_to_mask()
+        self.assertIsNone(target.input(0))
+
+    def test_set_input_to_first_available_skips_filled_slots(self):
+        existing = StubNode(name='Existing')
+        target = _make_target_node(max_inputs=3, inputs=[existing, None, None])
+        with self._patch_selected(target):
+            input_sets.set_input_to_first_available()
+        self.assertIs(target.input(0), existing)
+        self.assertIs(target.input(1), self._link_node)
+
+    def test_set_input_to_b_replaces_existing_input(self):
+        """Q on a Merge whose B is already wired must REPLACE the existing input."""
+        existing = StubNode(name='OldRead')
+        target = _make_target_node(max_inputs=3, inputs=[existing, None, None])
+        with self._patch_selected(target):
+            input_sets.set_input_to_b()
+        self.assertIs(target.input(0), self._link_node)
+        self.assertIsNot(target.input(0), existing)
+
+    def test_set_input_to_a_replaces_existing_input(self):
+        existing = StubNode(name='OldRead')
+        target = _make_target_node(max_inputs=3, inputs=[None, existing, None])
+        with self._patch_selected(target):
+            input_sets.set_input_to_a()
+        self.assertIs(target.input(1), self._link_node)
+
+    def test_set_input_to_mask_replaces_existing_input(self):
+        existing = StubNode(name='OldMask')
+        target = _make_target_node(node_class='Merge2', max_inputs=999,
+                                   inputs=[None, None, existing])
+        with self._patch_selected(target):
+            input_sets.set_input_to_mask()
+        self.assertIs(target.input(2), self._link_node)
+
+    def test_set_input_skipped_when_no_selection(self):
+        target = _make_target_node(max_inputs=3, inputs=[None, None, None])
+        with patch('input_sets.nuke.selectedNodes', return_value=[]):
+            input_sets.set_input_to_b()
+        self.assertIsNone(target.input(0))
+
+    def test_set_input_skipped_when_plugin_disabled(self):
+        target = _make_target_node(max_inputs=3, inputs=[None, None, None])
+        with patch('input_sets.prefs.plugin_enabled', False), self._patch_selected(target):
+            input_sets.set_input_to_b()
+        self.assertIsNone(target.input(0))
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_leader.py
+++ b/tests/test_leader.py
@@ -1,0 +1,361 @@
+"""Tests for leader.py — dispatch routing.
+
+The Qt event filter itself is not under test here (it requires a real
+QApplication and a stubbed PySide6 cannot exercise QEvent properly).
+Instead, we exercise leader.dispatch_key, which mirrors the eventFilter
+routing logic and is what the overlay's click cells call — so covering
+dispatch_key covers the routing decisions for both keyboard and mouse paths.
+
+What we verify:
+  - Single-shot keys (Q/W/E/F/J/Z/X/comma) call _disarm() before their dispatch.
+  - Chaining key (L) does NOT disarm and only hides the overlay.
+  - R is dynamic: when can_push_up_last_link is True it chains; otherwise it
+    disarms and opens the picker.
+  - When R is at top (push_up returns False), _flash_and_disarm is invoked.
+  - Unknown letters are silently ignored.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tests.stubs import make_stub_nuke_module
+
+if 'nuke' not in sys.modules:
+    sys.modules['nuke'] = make_stub_nuke_module()
+
+import leader
+
+
+class TestLeaderDispatchKey(unittest.TestCase):
+    """dispatch_key routes single-shot vs chaining vs dynamic-R correctly."""
+
+    def setUp(self):
+        # leader uses module-level state for arm/disarm; reset between tests.
+        leader._leader_active = True
+        leader._overlay = MagicMock()
+        # Routing tests assume the binding is enabled — the enable gate has its
+        # own dedicated TestIsBindingEnabled class below.
+        self._enable_patcher = patch('leader._is_binding_enabled', return_value=True)
+        self._enable_patcher.start()
+
+    def tearDown(self):
+        self._enable_patcher.stop()
+        leader._leader_active = False
+        leader._overlay = None
+
+    # ----- table structure -----
+
+    def test_q_table_entry_is_set_input_to_b(self):
+        from PySide6.QtCore import Qt
+        self.assertIs(leader._DISPATCH_TABLE[Qt.Key.Key_Q], leader._dispatch_set_input_to_b)
+
+    def test_w_table_entry_is_set_input_to_a(self):
+        from PySide6.QtCore import Qt
+        self.assertIs(leader._DISPATCH_TABLE[Qt.Key.Key_W], leader._dispatch_set_input_to_a)
+
+    def test_e_table_entry_is_set_input_to_mask(self):
+        from PySide6.QtCore import Qt
+        self.assertIs(leader._DISPATCH_TABLE[Qt.Key.Key_E], leader._dispatch_set_input_to_mask)
+
+    def test_l_is_chaining_not_single_shot(self):
+        from PySide6.QtCore import Qt
+        self.assertIn(Qt.Key.Key_L, leader._CHAINING_DISPATCH_TABLE)
+        self.assertNotIn(Qt.Key.Key_L, leader._DISPATCH_TABLE)
+
+    def test_r_default_is_single_shot(self):
+        from PySide6.QtCore import Qt
+        # R defaults to single-shot; chaining is decided at dispatch time.
+        self.assertIn(Qt.Key.Key_R, leader._DISPATCH_TABLE)
+
+    # ----- chaining vs single-shot routing -----
+
+    def test_q_disarms_and_runs_table_entry(self):
+        from PySide6.QtCore import Qt
+        sentinel = MagicMock(name='dispatch_q')
+        with patch.dict(leader._DISPATCH_TABLE, {Qt.Key.Key_Q: sentinel}), \
+             patch('leader._disarm') as mock_disarm:
+            leader.dispatch_key('Q')
+            mock_disarm.assert_called_once()
+            sentinel.assert_called_once()
+
+    def test_l_keypress_chains_without_disarm(self):
+        from PySide6.QtCore import Qt
+        sentinel = MagicMock(name='dispatch_l')
+        with patch.dict(leader._CHAINING_DISPATCH_TABLE, {Qt.Key.Key_L: sentinel}), \
+             patch('leader._disarm') as mock_disarm:
+            leader.dispatch_key('L')
+            mock_disarm.assert_not_called()
+            sentinel.assert_called_once()
+            leader._overlay.hide.assert_called_once()
+
+    def test_comma_keypress_opens_prefs_after_disarm(self):
+        from PySide6.QtCore import Qt
+        sentinel = MagicMock(name='dispatch_comma')
+        with patch.dict(leader._DISPATCH_TABLE, {Qt.Key.Key_Comma: sentinel}), \
+             patch('leader._disarm') as mock_disarm:
+            leader.dispatch_key(',')
+            mock_disarm.assert_called_once()
+            sentinel.assert_called_once()
+
+    def test_chaining_hides_overlay_with_suppression_flag_set(self):
+        """The overlay hide during chaining must be marked so hideEvent skips _disarm."""
+        from PySide6.QtCore import Qt
+        captured_flag = []
+
+        def _record_flag():
+            captured_flag.append(leader._suppress_disarm_on_hide)
+
+        leader._overlay.hide.side_effect = _record_flag
+        sentinel = MagicMock(name='dispatch_l')
+        with patch.dict(leader._CHAINING_DISPATCH_TABLE, {Qt.Key.Key_L: sentinel}):
+            leader.dispatch_key('L')
+        self.assertEqual(captured_flag, [True],
+                         "overlay.hide() must be called with _suppress_disarm_on_hide=True")
+        # Flag must be reset after the hide returns so subsequent click-outside
+        # hides still route through _disarm.
+        self.assertFalse(leader._suppress_disarm_on_hide)
+
+    # ----- R is now a plain single-shot picker -----
+
+    def test_r_opens_picker_via_dispatch_table(self):
+        from PySide6.QtCore import Qt
+        sentinel = MagicMock(name='dispatch_r')
+        with patch.dict(leader._DISPATCH_TABLE, {Qt.Key.Key_R: sentinel}), \
+             patch('leader._disarm') as mock_disarm:
+            leader.dispatch_key('R')
+            mock_disarm.assert_called_once()
+            sentinel.assert_called_once()
+
+    # ----- enable gate -----
+
+    def test_disabled_binding_disarms_silently(self):
+        """Pressing W when can_set_input_a is False must not fire the picker."""
+        from PySide6.QtCore import Qt
+        sentinel = MagicMock(name='dispatch_w')
+        with patch('leader._is_binding_enabled', return_value=False), \
+             patch.dict(leader._DISPATCH_TABLE, {Qt.Key.Key_W: sentinel}), \
+             patch('leader._disarm') as mock_disarm:
+            leader.dispatch_key('W')
+            mock_disarm.assert_called_once()
+            sentinel.assert_not_called()
+
+    def test_disabled_r_does_not_open_picker(self):
+        with patch('leader._is_binding_enabled', return_value=False), \
+             patch('leader._disarm') as mock_disarm, \
+             patch('leader._dispatch_set_input_first_available') as mock_picker:
+            leader.dispatch_key('R')
+            mock_disarm.assert_called_once()
+            mock_picker.assert_not_called()
+
+    # ----- bad input -----
+
+    def test_unknown_letter_is_ignored(self):
+        with patch('leader._disarm') as mock_disarm:
+            leader.dispatch_key('K')
+            mock_disarm.assert_not_called()
+
+
+class TestLayoutRemap(unittest.TestCase):
+    """_build_dispatch_tables honours the keyboard-layout remap."""
+
+    def test_qwerty_identity_when_no_remap(self):
+        original_remap = leader.LAYOUT_REMAP
+        leader.LAYOUT_REMAP = {}
+        try:
+            single, chaining, qt_to_letter = leader._build_dispatch_tables()
+        finally:
+            leader.LAYOUT_REMAP = original_remap
+        from PySide6.QtCore import Qt
+        self.assertIn(Qt.Key.Key_Q, single)
+        self.assertIn(Qt.Key.Key_L, chaining)
+        self.assertEqual(qt_to_letter[Qt.Key.Key_Q], 'Q')
+        self.assertEqual(qt_to_letter[Qt.Key.Key_L], 'L')
+
+    def test_azerty_remaps_q_to_physical_a(self):
+        original_remap = leader.LAYOUT_REMAP
+        leader.LAYOUT_REMAP = {"Q": "A", "W": "Z", "A": "Q", "Z": "W"}
+        try:
+            single, _chaining, qt_to_letter = leader._build_dispatch_tables()
+        finally:
+            leader.LAYOUT_REMAP = original_remap
+        from PySide6.QtCore import Qt
+        # On AZERTY, the physical key at QWERTY's Q position types 'A',
+        # so the dispatcher for 'Q' must be reachable via Qt.Key.Key_A.
+        self.assertIs(single[Qt.Key.Key_A], leader._dispatch_set_input_to_b)
+        # The reverse lookup maps physical Key_A back to canonical 'Q'.
+        self.assertEqual(qt_to_letter[Qt.Key.Key_A], 'Q')
+        # Qwerty 'Q' (physically at A position on AZERTY) must NOT still
+        # carry the Q binding.
+        self.assertNotIn(Qt.Key.Key_Q, single)
+
+    def test_physical_letter_for_passthrough(self):
+        original_remap = leader.LAYOUT_REMAP
+        leader.LAYOUT_REMAP = {}
+        try:
+            self.assertEqual(leader.physical_letter_for('F'), 'F')
+            self.assertEqual(leader.physical_letter_for(','), ',')
+        finally:
+            leader.LAYOUT_REMAP = original_remap
+
+    def test_physical_letter_for_azerty(self):
+        original_remap = leader.LAYOUT_REMAP
+        leader.LAYOUT_REMAP = {"Q": "A", "W": "Z"}
+        try:
+            self.assertEqual(leader.physical_letter_for('Q'), 'A')
+            self.assertEqual(leader.physical_letter_for('W'), 'Z')
+            self.assertEqual(leader.physical_letter_for('F'), 'F')
+        finally:
+            leader.LAYOUT_REMAP = original_remap
+
+
+class TestIsBindingEnabled(unittest.TestCase):
+    """_is_binding_enabled gates dispatch and overlay grey-out."""
+
+    def test_comma_always_enabled_even_when_plugin_disabled(self):
+        with patch.dict(sys.modules, {'prefs': MagicMock(plugin_enabled=False)}):
+            self.assertTrue(leader._is_binding_enabled(','))
+
+    def test_other_bindings_disabled_when_plugin_disabled(self):
+        with patch.dict(sys.modules, {'prefs': MagicMock(plugin_enabled=False)}):
+            self.assertFalse(leader._is_binding_enabled('Q'))
+            self.assertFalse(leader._is_binding_enabled('F'))
+
+    def test_w_disabled_when_target_has_only_one_input(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        fake_input_sets = MagicMock()
+        fake_input_sets.can_set_input_a.return_value = False
+        with patch.dict(sys.modules, {
+            'prefs': fake_prefs,
+            'input_sets': fake_input_sets,
+        }), patch('leader._selected_non_link_target', return_value=MagicMock()):
+            self.assertFalse(leader._is_binding_enabled('W'))
+
+    def test_e_disabled_when_no_mask_input(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        fake_input_sets = MagicMock()
+        fake_input_sets.can_set_input_mask.return_value = False
+        with patch.dict(sys.modules, {
+            'prefs': fake_prefs,
+            'input_sets': fake_input_sets,
+        }), patch('leader._selected_non_link_target', return_value=MagicMock()):
+            self.assertFalse(leader._is_binding_enabled('E'))
+
+    def test_r_disabled_when_no_free_input(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        fake_input_sets = MagicMock()
+        fake_input_sets.can_set_input_first_available.return_value = False
+        with patch.dict(sys.modules, {
+            'prefs': fake_prefs,
+            'input_sets': fake_input_sets,
+        }), patch('leader._selected_non_link_target', return_value=MagicMock()):
+            self.assertFalse(leader._is_binding_enabled('R'))
+
+    def test_r_enabled_when_free_input_available(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        fake_input_sets = MagicMock()
+        fake_input_sets.can_set_input_first_available.return_value = True
+        with patch.dict(sys.modules, {
+            'prefs': fake_prefs,
+            'input_sets': fake_input_sets,
+        }), patch('leader._selected_non_link_target', return_value=MagicMock()):
+            self.assertTrue(leader._is_binding_enabled('R'))
+
+    # ----- selection-aware gates for J / L / Z -----
+
+    def test_j_disabled_when_no_selection(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        with patch.dict(sys.modules, {'prefs': fake_prefs}), \
+             patch('leader._selected_single_node', return_value=None):
+            self.assertFalse(leader._is_binding_enabled('J'))
+
+    def test_j_disabled_when_selected_is_not_link(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        node = MagicMock()
+        with patch.dict(sys.modules, {'prefs': fake_prefs}), \
+             patch('leader._selected_single_node', return_value=node), \
+             patch('link.is_link', return_value=False):
+            self.assertFalse(leader._is_binding_enabled('J'))
+
+    def test_j_enabled_when_selected_is_link(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        node = MagicMock()
+        with patch.dict(sys.modules, {'prefs': fake_prefs}), \
+             patch('leader._selected_single_node', return_value=node), \
+             patch('link.is_link', return_value=True):
+            self.assertTrue(leader._is_binding_enabled('J'))
+
+    def test_l_disabled_when_no_selection(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        with patch.dict(sys.modules, {'prefs': fake_prefs}), \
+             patch('leader._selected_single_node', return_value=None):
+            self.assertFalse(leader._is_binding_enabled('L'))
+
+    def test_l_disabled_when_selected_is_not_anchor(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        node = MagicMock()
+        with patch.dict(sys.modules, {'prefs': fake_prefs}), \
+             patch('leader._selected_single_node', return_value=node), \
+             patch('link.is_anchor', return_value=False):
+            self.assertFalse(leader._is_binding_enabled('L'))
+
+    def test_l_enabled_when_selected_is_anchor(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        node = MagicMock()
+        with patch.dict(sys.modules, {'prefs': fake_prefs}), \
+             patch('leader._selected_single_node', return_value=node), \
+             patch('link.is_anchor', return_value=True):
+            self.assertTrue(leader._is_binding_enabled('L'))
+
+    def test_z_disabled_when_no_back_position(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        fake_anchor = MagicMock()
+        fake_anchor._back_position = None
+        with patch.dict(sys.modules, {'prefs': fake_prefs, 'anchor': fake_anchor}):
+            self.assertFalse(leader._is_binding_enabled('Z'))
+
+    def test_z_enabled_when_back_position_saved(self):
+        fake_prefs = MagicMock(plugin_enabled=True)
+        fake_anchor = MagicMock()
+        fake_anchor._back_position = (1.0, [0.0, 0.0])
+        with patch.dict(sys.modules, {'prefs': fake_prefs, 'anchor': fake_anchor}):
+            self.assertTrue(leader._is_binding_enabled('Z'))
+
+
+class TestLeaderArmDisarm(unittest.TestCase):
+    """arm() is idempotent and disarm() is safe to call when inactive."""
+
+    def setUp(self):
+        leader._leader_active = False
+        leader._filter = None
+        leader._overlay = None
+        leader._overlay_timer = None
+
+    def tearDown(self):
+        leader._leader_active = False
+
+    def test_disarm_is_noop_when_not_active(self):
+        # No exception, no state changes.
+        leader._disarm()
+        self.assertFalse(leader._leader_active)
+
+    def test_arm_sets_active_and_installs_filter(self):
+        fake_app = MagicMock()
+        with patch('leader.QApplication.instance', return_value=fake_app), \
+             patch('leader.LeaderKeyFilter') as fake_filter_class:
+            fake_filter_class.return_value = MagicMock()
+            # Patch the overlay import so arm() doesn't reach into PySide6 widget land.
+            with patch.dict(sys.modules, {'leader_overlay': MagicMock()}):
+                leader.arm()
+        self.assertTrue(leader._leader_active)
+        fake_app.installEventFilter.assert_called_once()
+
+    def test_arm_when_already_active_is_noop(self):
+        leader._leader_active = True
+        with patch('leader.QApplication.instance') as mock_instance:
+            leader.arm()
+            mock_instance.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_leader.py
+++ b/tests/test_leader.py
@@ -7,12 +7,16 @@ routing logic and is what the overlay's click cells call — so covering
 dispatch_key covers the routing decisions for both keyboard and mouse paths.
 
 What we verify:
-  - Single-shot keys (Q/W/E/F/J/Z/X/comma) call _disarm() before their dispatch.
-  - Chaining key (L) does NOT disarm and only hides the overlay.
-  - R is dynamic: when can_push_up_last_link is True it chains; otherwise it
-    disarms and opens the picker.
-  - When R is at top (push_up returns False), _flash_and_disarm is invoked.
+  - Single-shot keys (Q/W/E/R/F/J/Z/X/comma) disarm leader mode first, then
+    invoke their entry in _DISPATCH_TABLE.
+  - The chaining key L hides the overlay through _hide_overlay_for_chaining
+    (so hideEvent does not re-disarm) and stays armed.
+  - Pressing a disabled binding (per _is_binding_enabled) silently disarms
+    without invoking the dispatcher.
+  - The selection-aware enable gates for J / L / Z behave as documented.
   - Unknown letters are silently ignored.
+  - The keyboard-layout remap rewrites the Qt.Key codes in the dispatch
+    tables so the user's physical-key muscle memory is preserved.
 """
 
 import sys

--- a/tests/test_leader.py
+++ b/tests/test_leader.py
@@ -20,6 +20,7 @@ What we verify:
 """
 
 import sys
+import types
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -28,7 +29,23 @@ from tests.stubs import make_stub_nuke_module
 if 'nuke' not in sys.modules:
     sys.modules['nuke'] = make_stub_nuke_module()
 
-import leader
+leader = None
+
+
+def setUpModule():
+    """Import leader against a stable in-memory prefs stub for this test file."""
+    prefs_stub = types.ModuleType('prefs')
+    prefs_stub.keyboard_layout = 'qwerty'
+    prefs_stub.plugin_enabled = True
+    sys.modules['prefs'] = prefs_stub
+    global leader
+    import leader as leader_module
+    leader = leader_module
+
+
+def tearDownModule():
+    sys.modules.pop('prefs', None)
+    sys.modules.pop('leader', None)
 
 
 class TestLeaderDispatchKey(unittest.TestCase):
@@ -211,6 +228,70 @@ class TestLayoutRemap(unittest.TestCase):
             self.assertEqual(leader.physical_letter_for('F'), 'F')
         finally:
             leader.LAYOUT_REMAP = original_remap
+
+
+class TestRemapFromPrefs(unittest.TestCase):
+    """_remap_from_prefs reads the layout pref and returns the right table."""
+
+    def test_qwerty_returns_empty_dict(self):
+        with patch.dict(sys.modules, {'prefs': MagicMock(keyboard_layout='qwerty')}):
+            self.assertEqual(leader._remap_from_prefs(), {})
+
+    def test_azerty_returns_azerty_table(self):
+        with patch.dict(sys.modules, {'prefs': MagicMock(keyboard_layout='azerty')}):
+            self.assertEqual(leader._remap_from_prefs(), leader._AZERTY_REMAP)
+
+    def test_qwertz_returns_qwertz_table(self):
+        with patch.dict(sys.modules, {'prefs': MagicMock(keyboard_layout='qwertz')}):
+            self.assertEqual(leader._remap_from_prefs(), leader._QWERTZ_REMAP)
+
+    def test_unknown_value_returns_empty_dict(self):
+        with patch.dict(sys.modules, {'prefs': MagicMock(keyboard_layout='dvorak')}):
+            self.assertEqual(leader._remap_from_prefs(), {})
+
+    def test_prefs_import_failure_returns_empty_dict(self):
+        # Force the import inside _remap_from_prefs to fail by injecting a sentinel
+        # that raises on attribute access.
+        class RaisingModule:
+            def __getattr__(self, _name):
+                raise RuntimeError("simulated prefs failure")
+        with patch.dict(sys.modules, {'prefs': RaisingModule()}):
+            self.assertEqual(leader._remap_from_prefs(), {})
+
+
+class TestRebuildLayout(unittest.TestCase):
+    """rebuild_layout re-derives LAYOUT_REMAP and dispatch tables from prefs."""
+
+    def setUp(self):
+        self._original_remap = leader.LAYOUT_REMAP
+        self._original_dispatch = leader._DISPATCH_TABLE
+        self._original_chaining = leader._CHAINING_DISPATCH_TABLE
+        self._original_qt_to_letter = leader._QT_KEY_TO_LETTER
+
+    def tearDown(self):
+        leader.LAYOUT_REMAP = self._original_remap
+        leader._DISPATCH_TABLE = self._original_dispatch
+        leader._CHAINING_DISPATCH_TABLE = self._original_chaining
+        leader._QT_KEY_TO_LETTER = self._original_qt_to_letter
+
+    def test_rebuild_applies_azerty(self):
+        from PySide6.QtCore import Qt
+        with patch.dict(sys.modules, {'prefs': MagicMock(keyboard_layout='azerty')}):
+            leader.rebuild_layout()
+        # On AZERTY, Q's binding moves to the physical A key.
+        self.assertIs(leader._DISPATCH_TABLE[Qt.Key.Key_A], leader._dispatch_set_input_to_b)
+        self.assertEqual(leader._QT_KEY_TO_LETTER[Qt.Key.Key_A], 'Q')
+        self.assertEqual(leader.LAYOUT_REMAP, leader._AZERTY_REMAP)
+
+    def test_rebuild_back_to_qwerty(self):
+        from PySide6.QtCore import Qt
+        # First switch to azerty, then back to qwerty.
+        with patch.dict(sys.modules, {'prefs': MagicMock(keyboard_layout='azerty')}):
+            leader.rebuild_layout()
+        with patch.dict(sys.modules, {'prefs': MagicMock(keyboard_layout='qwerty')}):
+            leader.rebuild_layout()
+        self.assertIs(leader._DISPATCH_TABLE[Qt.Key.Key_Q], leader._dispatch_set_input_to_b)
+        self.assertEqual(leader.LAYOUT_REMAP, {})
 
 
 class TestIsBindingEnabled(unittest.TestCase):

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -861,5 +861,100 @@ class TestLastPublishPath(unittest.TestCase):
             )
 
 
+class TestKeyboardLayoutPref(unittest.TestCase):
+    """Round-trip tests for the keyboard_layout preference field."""
+
+    def setUp(self):
+        if 'prefs' in sys.modules:
+            del sys.modules['prefs']
+
+    def tearDown(self):
+        if 'prefs' in sys.modules:
+            del sys.modules['prefs']
+
+    def _reload_prefs_with_temp_path(self, temp_prefs_path):
+        import constants
+        original_prefs_path = constants.PREFS_PATH
+        original_palette_path = constants.USER_PALETTE_PATH
+        original_old_prefs_path = constants.OLD_PREFS_PATH
+        try:
+            constants.PREFS_PATH = temp_prefs_path
+            constants.USER_PALETTE_PATH = temp_prefs_path + '.palette_unused'
+            constants.OLD_PREFS_PATH = temp_prefs_path + '.old_unused'
+            if 'prefs' in sys.modules:
+                del sys.modules['prefs']
+            import prefs as reloaded_prefs
+            reloaded_prefs.PREFS_PATH = temp_prefs_path
+            return reloaded_prefs
+        finally:
+            constants.PREFS_PATH = original_prefs_path
+            constants.USER_PALETTE_PATH = original_palette_path
+            constants.OLD_PREFS_PATH = original_old_prefs_path
+
+    def test_keyboard_layout_defaults_to_qwerty(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_prefs_path = os.path.join(temp_dir, 'anchors_prefs.json')
+            self.assertFalse(os.path.exists(temp_prefs_path))
+
+            prefs_module = self._reload_prefs_with_temp_path(temp_prefs_path)
+
+            self.assertEqual(prefs_module.keyboard_layout, 'qwerty')
+
+    def test_keyboard_layout_round_trips(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_prefs_path = os.path.join(temp_dir, 'anchors_prefs.json')
+            prefs_module = self._reload_prefs_with_temp_path(temp_prefs_path)
+
+            prefs_module.keyboard_layout = 'azerty'
+            prefs_module.save()
+
+            with open(temp_prefs_path) as file_handle:
+                data = json.load(file_handle)
+            self.assertEqual(data['keyboard_layout'], 'azerty')
+
+            prefs_module2 = self._reload_prefs_with_temp_path(temp_prefs_path)
+            self.assertEqual(prefs_module2.keyboard_layout, 'azerty')
+
+    def test_keyboard_layout_invalid_value_in_json_is_ignored(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_prefs_path = os.path.join(temp_dir, 'anchors_prefs.json')
+
+            prefs_data = {
+                'plugin_enabled': True,
+                'custom_colors': [],
+                'naming_regex': '',
+                'naming_template': '',
+                'naming_demo_filename': 'plate_v003.exr',
+                'site_config_override': False,
+                'last_publish_path': '',
+                'keyboard_layout': 'dvorak',  # not in _VALID_KEYBOARD_LAYOUTS
+            }
+            with open(temp_prefs_path, 'w') as file_handle:
+                json.dump(prefs_data, file_handle)
+
+            prefs_module = self._reload_prefs_with_temp_path(temp_prefs_path)
+
+            self.assertEqual(
+                prefs_module.keyboard_layout,
+                'qwerty',
+                "Unknown keyboard_layout value must fall back to default 'qwerty'",
+            )
+
+    def test_keyboard_layout_missing_key_keeps_default(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_prefs_path = os.path.join(temp_dir, 'anchors_prefs.json')
+
+            prefs_data = {
+                'plugin_enabled': True,
+                'custom_colors': [],
+            }
+            with open(temp_prefs_path, 'w') as file_handle:
+                json.dump(prefs_data, file_handle)
+
+            prefs_module = self._reload_prefs_with_temp_path(temp_prefs_path)
+
+            self.assertEqual(prefs_module.keyboard_layout, 'qwerty')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a `Shift+A` **leader-key** overlay that surfaces every anchor command as a single follow-up keystroke, modelled on the sibling `node_layout` plugin. Closes #50 by delivering Set B / A / Mask / First-Free Input To… as `Q` / `W` / `E` / `R`.

## What's new

**Leader bindings (Shift+A then…)**

| Key | Action |
|---|---|
| `Q` / `W` / `E` | Set B / A / Mask input → opens picker, replaces existing wiring |
| `R` | Set first available input → opens picker, only fills empty slots |
| `F` / `J` / `L` / `Z` | Find / Jump / Cycle Links (chaining) / Back |
| `X` | Reconnect All Links |
| `,` | Anchor Preferences |

Mask resolution: input 2 on Merge-style multi-input nodes (`maxInputs() > 100`), last input on others.

**Selection-aware grey-out** — a binding's cell greys when its precondition isn't met:
- `W` greys on a single-input node, `E` greys when no mask input exists
- `R` greys when every slot is filled
- `J` greys unless a Link is selected, `L` greys unless an anchor is selected
- `Z` greys unless there's a saved jump-back position
- All anchor cells grey when the plugin is disabled (only `,` stays active)

Pressing a greyed key disarms the leader silently.

**Layout-aware** — detects AZERTY / QWERTZ via `QLocale` and renders the letter physically printed on each user key, so the `Q` cell shows `A` on AZERTY while still triggering Set-B-Input.

**Chaining** — `L` stays armed for repeated presses (cycle through links). Any other key or mouse click disarms.

The existing `Alt+A` / `Alt+J` / `Alt+L` / `Alt+Z` shortcuts continue to work alongside for muscle-memory parity.

## Files

| New | Modified |
|---|---|
| `leader.py` — filter, dispatch tables, layout remap | `constants.py` — `LEADER_BINDINGS` source of truth |
| `leader_overlay.py` — translucent HUD with QWERTY-positioned cells | `anchor.py` — `pick_anchor()` helper extracted |
| `input_sets.py` — `set_input_to_*` + `can_*` predicates | `menu.py` — `Shift+A` registered as gated command, `shortcutContext=2` |
| `tests/test_leader.py` (34 tests) | `.github/workflows/release.yml` — new modules added to release ZIP |
| `tests/test_input_sets.py` (20 tests) | `README.md` / `docs/quick-start.md` — Leader Key sections |

## Test plan

- [x] Full test suite: 447 passing (54 new)
- [ ] UAT in Nuke — golden path:
  - [ ] Shift+A → overlay appears within ~200 ms with QWERTY-positioned cells
  - [ ] Q/W/E/R wire links into B/A/Mask/first-free slots; Q/W/E replace existing wiring
  - [ ] Multiple links staggered ~150 px horizontally so they don't overlap
  - [ ] Greyed cells (single-input W, no-mask E, full-slots R, no-Link J, no-anchor L, no-back-pos Z) disarm silently when pressed
  - [ ] L chains: repeated L cycles through links until any other key or click
  - [ ] Click outside dismisses without taskbar flash (Linux/Windows)
  - [ ] Plugin disabled → only comma cell active
  - [ ] alt+A / alt+J / alt+L / alt+Z still work as before

Closes #50