### PR TITLE
fix: dots no longer get brown "Local: …" labels on copy (#56)

### DIFF
--- a/anchors.py
+++ b/anchors.py
@@ -1,5 +1,6 @@
 """Copy-cut-paste behaviour that re-connects hidden inputs."""
 
+import contextlib
 import os
 
 import nuke
@@ -19,7 +20,9 @@ from constants import (
     DOT_TYPE_KNOB_NAME,
     HIDDEN_INPUT_CLASSES,
     KNOB_NAME,
+    LINK_RECONNECT_KNOB_NAME,
     LOCAL_DOT_COLOR,
+    TAB_NAME,
 )
 from link import (
     add_input_knob,
@@ -58,6 +61,71 @@ def _legacy_stem_fqnn(input_node, script_stem):
     return f"{script_stem}.{get_fully_qualified_node_name(input_node)}"
 
 
+def _stamp_as_link_dot(node, input_node):
+    """Stamp *node* as a Link Dot pointing at *input_node* (an anchor).
+
+    Anchor-backed and cross-script capable.  Overrides tile_color to canonical
+    purple — setup_link_node() may apply a custom anchor color via
+    find_node_color(), which we do not want here.
+    """
+    add_input_knob(node, dot_type='link')
+    setup_link_node(input_node, node)
+    node['tile_color'].setValue(ANCHOR_DEFAULT_COLOR)
+
+
+def _stamp_as_local_dot(node, input_node, script_stem):
+    """Stamp *node* as a Local Dot pointing at *input_node* (a plain node).
+
+    Plain-node-backed and same-script only.  Restores the Local appearance
+    after setup_link_node() overwrites label/color.
+    """
+    stored_fqnn = _legacy_stem_fqnn(input_node, script_stem)
+    setup_link_node(input_node, node)
+    add_input_knob(node, dot_type='local')
+    _restore_local_dot_appearance(node, _source_label_for(input_node))
+    node[KNOB_NAME].setText(stored_fqnn)
+
+
+def _snapshot_node_state(node):
+    """Capture enough of *node*'s state to undo any stamping done before nodeCopy().
+
+    Records the current set of knob names (so knobs added by stamping can be
+    removed on restore) and the values of the appearance/custom knobs that the
+    stamping helpers may overwrite.
+    """
+    knob_names = set(node.knobs())
+    saved_values = {}
+    for knob_name in ('label', 'tile_color', 'note_font_size', 'hide_input',
+                      KNOB_NAME, DOT_TYPE_KNOB_NAME):
+        if knob_name in knob_names:
+            saved_values[knob_name] = node[knob_name].getValue()
+    return {'knob_names': knob_names, 'saved_values': saved_values}
+
+
+def _restore_node_state(node, snapshot):
+    """Revert *node* to the state captured by _snapshot_node_state().
+
+    Removes any knob added since the snapshot (TAB_NAME, KNOB_NAME,
+    DOT_TYPE_KNOB_NAME, LINK_RECONNECT_KNOB_NAME) and writes the saved values
+    back to the knobs that survive.  Keeps copy_anchors() non-destructive: the
+    clipboard already captured the stamped state, so the live original can be
+    returned to exactly how the user left it.
+    """
+    for knob_name in list(node.knobs()):
+        if knob_name not in snapshot['knob_names']:
+            with contextlib.suppress(Exception):
+                node.removeKnob(node[knob_name])
+    for knob_name, saved_value in snapshot['saved_values'].items():
+        if knob_name not in node.knobs():
+            continue
+        try:
+            node[knob_name].setValue(saved_value)
+        except TypeError:
+            # Integer knobs (e.g. tile_color) return a float from getValue() but
+            # require an int on setValue().
+            node[knob_name].setValue(int(saved_value))
+
+
 def _stamp_for_link(node, selected_nodes, script_stem):
     """Path L — existing link nodes: re-setup from the current live input so the
     clipboard copy always reflects fresh state.  Anchors that also carry a stale
@@ -73,13 +141,8 @@ def _stamp_for_link(node, selected_nodes, script_stem):
         add_input_knob(node, dot_type='link')
         setup_link_node(input_node, node)
     else:
-        # Local Dot: restore Local appearance after setup_link_node() overwrites
-        # label/color, matching the behaviour of Path B for non-link hidden-input nodes.
-        stored_fqnn = _legacy_stem_fqnn(input_node, script_stem)
-        setup_link_node(input_node, node)
-        add_input_knob(node, dot_type='local')
-        _restore_local_dot_appearance(node, _source_label_for(input_node))
-        node[KNOB_NAME].setText(stored_fqnn)
+        # Local Dot: matches the behaviour of Path B for non-link hidden-input nodes.
+        _stamp_as_local_dot(node, input_node, script_stem)
 
 
 def _stamp_for_hidden_dot(node, selected_nodes, script_stem):
@@ -93,19 +156,10 @@ def _stamp_for_hidden_dot(node, selected_nodes, script_stem):
         node[KNOB_NAME].setText(stored_fqnn)
     elif is_anchor(input_node):
         # Link Dot: anchor-backed, cross-script capable.
-        # Override tile_color to canonical purple — setup_link_node() may apply a
-        # custom anchor color via find_node_color(), which we do not want here.
-        add_input_knob(node, dot_type='link')
-        setup_link_node(input_node, node)
-        node['tile_color'].setValue(ANCHOR_DEFAULT_COLOR)
+        _stamp_as_link_dot(node, input_node)
     else:
         # Local Dot: plain-node-backed, same-script only.
-        # Restore Local appearance after setup_link_node() overwrites label/color.
-        stored_fqnn = _legacy_stem_fqnn(input_node, script_stem)
-        setup_link_node(input_node, node)
-        add_input_knob(node, dot_type='local')
-        _restore_local_dot_appearance(node, _source_label_for(input_node))
-        node[KNOB_NAME].setText(stored_fqnn)
+        _stamp_as_local_dot(node, input_node, script_stem)
 
 
 def _stamp_for_anchor(node, selection_is_all_anchors, cut):
@@ -143,6 +197,11 @@ def copy_anchors(cut=False):
         selected_nodes = nuke.selectedNodes()
         selection_is_all_anchors = bool(selected_nodes) and all(is_anchor(n) for n in selected_nodes)
         script_stem = _get_script_stem()
+        # Snapshot every selected node before stamping so the live originals can
+        # be restored afterwards.  The stamps only need to reach the clipboard
+        # (serialised by nodeCopy below); persisting them on the originals is the
+        # cause of issue #56, where copying alone mutated the node in the DAG.
+        snapshots = {node: _snapshot_node_state(node) for node in selected_nodes}
         for node in selected_nodes:
             if is_link(node) and not is_anchor(node):
                 _stamp_for_link(node, selected_nodes, script_stem)
@@ -153,6 +212,13 @@ def copy_anchors(cut=False):
 
         # now that we've stored the info we need on the nodes, do a regular copy
         nuke.nodeCopy(nukescripts.cut_paste_file())
+
+        # Restore the originals so copying is non-destructive (issue #56).  Skip
+        # on the cut path: those nodes are deleted immediately by cut_anchors(),
+        # so restoring them would be wasted work.
+        if not cut:
+            for node in selected_nodes:
+                _restore_node_state(node, snapshots[node])
 
 
 def cut_anchors():
@@ -171,6 +237,83 @@ def cut_anchors():
     copy_anchors(cut=True)
     for node in selected_nodes:
         nuke.delete(node)
+
+
+def _convert_hidden_dot_in_place(node, script_stem):
+    """Convert a freshly-hidden, wired Dot into a Local/Link dot in place.
+
+    No-op if the node is already marked (a link or anchor) or has no upstream
+    input.  This is the deliberate "manual link" gesture that previously relied
+    on the side effect of copy_anchors() stamping the original (issue #56).
+    """
+    if is_link(node) or is_anchor(node):
+        return
+    input_node = node.input(0)
+    if input_node is None:
+        return
+    if is_anchor(input_node):
+        _stamp_as_link_dot(node, input_node)
+    else:
+        _stamp_as_local_dot(node, input_node, script_stem)
+
+
+def toggle_input_visibility():
+    """Wrap Nuke's Edit > Node > Input On/Off (Alt+H).
+
+    Toggles hide_input on the selected nodes (the built-in effect).  When a wired
+    Dot/NoOp/PostageStamp has its input *hidden*, it is converted into a
+    Local/Link dot in place; when its input is *revealed* again, any link state is
+    cleared so it reverts to a plain node.  Mirrors how copy_anchors() wraps
+    nuke.nodeCopy(): the built-in toggle always runs (even when the plugin is
+    disabled); the stamping/clearing only happens when the plugin is enabled.
+    """
+    with nuke.lastHitGroup():
+        selected_nodes = nuke.selectedNodes()
+        script_stem = _get_script_stem()
+        for node in selected_nodes:
+            if 'hide_input' not in node.knobs():
+                continue
+            now_hidden = not node['hide_input'].value()
+            node['hide_input'].setValue(now_hidden)
+            if not prefs.plugin_enabled or node.Class() not in HIDDEN_INPUT_CLASSES:
+                continue
+            if now_hidden:
+                _convert_hidden_dot_in_place(node, script_stem)
+            else:
+                # Revealing the input reverts the dot to a plain node.
+                # _clear_link_state() self-guards: it only acts on marked dots.
+                _clear_link_state(node)
+
+
+def _clear_link_state(node):
+    """Strip the anchor/link stamping from *node*, reverting it to a plain node.
+
+    Removes the custom knobs (KNOB_NAME, DOT_TYPE_KNOB_NAME, TAB_NAME,
+    LINK_RECONNECT_KNOB_NAME), clears the "Local: …"/"Link: …" label and tile
+    colour, and reveals the input again.  No-op on anchors and on nodes that
+    carry no link state.  The input connection is left intact.
+    """
+    if is_anchor(node) or not is_link(node):
+        return
+    for knob_name in (DOT_TYPE_KNOB_NAME, KNOB_NAME, TAB_NAME, LINK_RECONNECT_KNOB_NAME):
+        with contextlib.suppress(Exception):
+            node.removeKnob(node[knob_name])
+    with contextlib.suppress(Exception):
+        node['label'].setValue('')
+    with contextlib.suppress(Exception):
+        node['tile_color'].setValue(0)
+    with contextlib.suppress(Exception):
+        node['hide_input'].setValue(False)
+
+
+def clear_link_state():
+    """Revert the selected Local/Link dots to plain nodes (undo Input On/Off
+    conversion).  Anchors and unmarked nodes are left untouched."""
+    if not prefs.plugin_enabled:
+        return
+    with nuke.lastHitGroup():
+        for node in nuke.selectedNodes():
+            _clear_link_state(node)
 
 
 def _extract_display_name_from_fqnn(stored_fqnn):

--- a/anchors.py
+++ b/anchors.py
@@ -303,6 +303,13 @@ def _clear_link_state(node):
     with contextlib.suppress(Exception):
         node['tile_color'].setValue(0)
     with contextlib.suppress(Exception):
+        # Revert the link-label font bump from setup_link_node() so the reverted
+        # dot drops below DOT_ANCHOR_MIN_FONT_SIZE and is not re-detected as an
+        # anchor once it is re-labelled.  Using the knob default avoids hardcoding
+        # a size; a freshly-created plain Dot round-trips exactly.
+        font_knob = node['note_font_size']
+        font_knob.setValue(font_knob.defaultValue())
+    with contextlib.suppress(Exception):
         node['hide_input'].setValue(False)
 
 

--- a/menu.py
+++ b/menu.py
@@ -11,6 +11,9 @@ edit_menu = menu.findItem("Edit")
 menu.addCommand("Edit/Copy",  "anchors.copy_anchors()",  "^C")
 menu.addCommand("Edit/Cut",   "anchors.cut_anchors()",   "^X")
 menu.addCommand("Edit/Paste", "anchors.paste_anchors()", "^V")
+# Wrap the built-in Input On/Off so hiding a wired Dot's input stamps it into a
+# Local/Link dot in place (issue #56 — replaces the old copy-time side effect).
+menu.addCommand("Edit/Node/Input On/Off", "anchors.toggle_input_visibility()", "alt+h")
 
 def _find_item_index(parent_menu, item_name):
     for position, menu_item in enumerate(parent_menu.items()):
@@ -49,6 +52,7 @@ def _add_gated_command(menu, name, command, shortcut=None, shortcut_context=None
 _add_gated_command(anchors_menu, "Create Anchor",       "anchor.create_anchor()")
 _add_gated_command(anchors_menu, "Rename Anchor",       "anchor.rename_selected_anchor()")
 _add_gated_command(anchors_menu, "Create Link",                "anchor.select_anchor_and_create()")
+_add_gated_command(anchors_menu, "Clear Link State",    "anchors.clear_link_state()")
 _add_gated_command(anchors_menu, "Anchor",              "anchor.anchor_shortcut()",            "A")
 _add_gated_command(anchors_menu, "Leader Key",          "import leader; leader.arm()",         "+A",
                    shortcut_context=2)

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -107,7 +107,7 @@ class StubNode:
         self._knobs[knob.name()] = knob
 
     def removeKnob(self, knob):
-        pass
+        self._knobs.pop(knob.name(), None)
 
     def __getitem__(self, knob_name):
         if knob_name not in self._knobs:
@@ -142,7 +142,7 @@ def make_stub_nuke_module():
     stub.delete = MagicMock()
     stub.INVISIBLE = 0
     stub.NUKE_VERSION_MAJOR = 16  # critical: forces PySide6 path in anchor.py; do NOT use 14
-    stub.PyScript_Knob = MagicMock()
+    stub.PyScript_Knob = MagicMock(side_effect=lambda name, *args: StubKnob(knob_name=name))
     stub.String_Knob = MagicMock(side_effect=lambda name, *args: StubKnob(knob_name=name))
     stub.Tab_Knob = MagicMock(side_effect=lambda name, *args: StubKnob(knob_name=name))
     stub.Boolean_Knob = MagicMock(side_effect=lambda name, *args: StubKnob(knob_name=name))

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -22,10 +22,13 @@ class StubKnob:
     It defaults to '' so that existing StubKnob(value) calls remain unchanged.
     """
 
-    def __init__(self, value='', knob_name=''):
+    def __init__(self, value='', knob_name='', default=None):
         self._value = value
         self._visible = True
         self._knob_name = knob_name
+        # Falls back to the initial value when no explicit default is given, so
+        # knobs created without a default behave sensibly under defaultValue().
+        self._default = value if default is None else default
 
     def name(self):
         return self._knob_name
@@ -41,6 +44,9 @@ class StubKnob:
 
     def value(self):
         return self._value
+
+    def defaultValue(self):
+        return self._default
 
     def setVisible(self, visible):
         self._visible = visible

--- a/tests/test_clear_link_state.py
+++ b/tests/test_clear_link_state.py
@@ -8,6 +8,8 @@ import unittest
 from unittest.mock import patch
 
 from constants import (
+    DOT_ANCHOR_MIN_FONT_SIZE,
+    DOT_LINK_LABEL_FONT_SIZE,
     DOT_TYPE_KNOB_NAME,
     KNOB_NAME,
     LINK_RECONNECT_KNOB_NAME,
@@ -16,9 +18,13 @@ from constants import (
 )
 from tests.stubs import StubKnob, StubNode
 
+# A plain Dot's font size sits below the anchor threshold; the link conversion
+# bumps it up to DOT_LINK_LABEL_FONT_SIZE (== DOT_ANCHOR_MIN_FONT_SIZE).
+PLAIN_DOT_FONT_DEFAULT = DOT_ANCHOR_MIN_FONT_SIZE - 22
 
-def _make_knob(value='', knob_name=''):
-    return StubKnob(value=value, knob_name=knob_name)
+
+def _make_knob(value='', knob_name='', default=None):
+    return StubKnob(value=value, knob_name=knob_name, default=default)
 
 
 def _make_local_dot():
@@ -30,6 +36,9 @@ def _make_local_dot():
         'label': _make_knob('Local: my merge'),
         'tile_color': _make_knob(LOCAL_DOT_COLOR),
         'hide_input': _make_knob(True, knob_name='hide_input'),
+        'note_font_size': _make_knob(DOT_LINK_LABEL_FONT_SIZE,
+                                     knob_name='note_font_size',
+                                     default=PLAIN_DOT_FONT_DEFAULT),
     })
 
 
@@ -98,6 +107,48 @@ class TestClearLinkState(unittest.TestCase):
 
         self.assertEqual(plain['label'].getValue(), 'just a note')
         self.assertEqual(plain['tile_color'].getValue(), 456)
+
+    def test_clear_resets_note_font_size_to_default(self):
+        """Clearing must drop the link-label font bump back to the knob default."""
+        dot = _make_local_dot()
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False):
+
+            mock_prefs.plugin_enabled = True
+            mock_nuke.selectedNodes.return_value = [dot]
+
+            from anchors import clear_link_state
+            clear_link_state()
+
+        self.assertEqual(dot['note_font_size'].value(), PLAIN_DOT_FONT_DEFAULT)
+
+    def test_cleared_dot_is_not_an_anchor_after_relabel(self):
+        """Regression: a cleared dot must fall below the anchor font gate, so
+        re-labelling it does not make is_anchor() (the real predicate) return True."""
+        from link import is_anchor as real_is_anchor
+
+        dot = _make_local_dot()
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False):
+
+            mock_prefs.plugin_enabled = True
+            mock_nuke.selectedNodes.return_value = [dot]
+
+            from anchors import clear_link_state
+            clear_link_state()
+
+        # The user re-labels the now-plain dot.
+        dot['label'].setValue('my note')
+        self.assertFalse(
+            real_is_anchor(dot),
+            "A cleared, re-labelled dot must remain a plain note, not an anchor",
+        )
 
     def test_clear_noop_when_plugin_disabled(self):
         dot = _make_local_dot()

--- a/tests/test_clear_link_state.py
+++ b/tests/test_clear_link_state.py
@@ -1,0 +1,122 @@
+"""Tests for clear_link_state() — reverting a Local/Link dot back to a plain node.
+
+This is the inverse of the Input On/Off (Alt+H) conversion: it strips the custom
+knobs, clears the stamped label/colour, and reveals the input again.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from constants import (
+    DOT_TYPE_KNOB_NAME,
+    KNOB_NAME,
+    LINK_RECONNECT_KNOB_NAME,
+    LOCAL_DOT_COLOR,
+    TAB_NAME,
+)
+from tests.stubs import StubKnob, StubNode
+
+
+def _make_knob(value='', knob_name=''):
+    return StubKnob(value=value, knob_name=knob_name)
+
+
+def _make_local_dot():
+    return StubNode(name='Dot1', node_class='Dot', knobs_dict={
+        KNOB_NAME: _make_knob('sourceScript.Merge1', knob_name=KNOB_NAME),
+        DOT_TYPE_KNOB_NAME: _make_knob('local', knob_name=DOT_TYPE_KNOB_NAME),
+        TAB_NAME: _make_knob('', knob_name=TAB_NAME),
+        LINK_RECONNECT_KNOB_NAME: _make_knob('', knob_name=LINK_RECONNECT_KNOB_NAME),
+        'label': _make_knob('Local: my merge'),
+        'tile_color': _make_knob(LOCAL_DOT_COLOR),
+        'hide_input': _make_knob(True, knob_name='hide_input'),
+    })
+
+
+class TestClearLinkState(unittest.TestCase):
+
+    def test_clear_reverts_local_dot_to_plain(self):
+        dot = _make_local_dot()
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False):
+
+            mock_prefs.plugin_enabled = True
+            mock_nuke.selectedNodes.return_value = [dot]
+
+            from anchors import clear_link_state
+            clear_link_state()
+
+        for knob_name in (KNOB_NAME, DOT_TYPE_KNOB_NAME, TAB_NAME, LINK_RECONNECT_KNOB_NAME):
+            self.assertNotIn(knob_name, dot.knobs())
+        self.assertEqual(dot['label'].getValue(), '')
+        self.assertEqual(dot['tile_color'].getValue(), 0)
+        self.assertFalse(dot['hide_input'].value())
+
+    def test_clear_leaves_anchor_untouched(self):
+        anchor = StubNode(name='Anchor_Foo', node_class='NoOp', knobs_dict={
+            KNOB_NAME: _make_knob('Anchor_Foo', knob_name=KNOB_NAME),
+            'label': _make_knob('Foo'),
+            'tile_color': _make_knob(123),
+            'hide_input': _make_knob(False),
+        })
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=True):
+
+            mock_prefs.plugin_enabled = True
+            mock_nuke.selectedNodes.return_value = [anchor]
+
+            from anchors import clear_link_state
+            clear_link_state()
+
+        self.assertIn(KNOB_NAME, anchor.knobs())
+        self.assertEqual(anchor['label'].getValue(), 'Foo')
+        self.assertEqual(anchor['tile_color'].getValue(), 123)
+
+    def test_clear_leaves_unmarked_node_untouched(self):
+        plain = StubNode(name='Dot1', node_class='Dot', knobs_dict={
+            'label': _make_knob('just a note'),
+            'tile_color': _make_knob(456),
+            'hide_input': _make_knob(False),
+        })
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False):
+
+            mock_prefs.plugin_enabled = True
+            mock_nuke.selectedNodes.return_value = [plain]
+
+            from anchors import clear_link_state
+            clear_link_state()
+
+        self.assertEqual(plain['label'].getValue(), 'just a note')
+        self.assertEqual(plain['tile_color'].getValue(), 456)
+
+    def test_clear_noop_when_plugin_disabled(self):
+        dot = _make_local_dot()
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False):
+
+            mock_prefs.plugin_enabled = False
+            mock_nuke.selectedNodes.return_value = [dot]
+
+            from anchors import clear_link_state
+            clear_link_state()
+
+        # Nothing stripped.
+        self.assertIn(KNOB_NAME, dot.knobs())
+        self.assertEqual(dot['label'].getValue(), 'Local: my merge')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_copy_anchor_as_link.py
+++ b/tests/test_copy_anchor_as_link.py
@@ -133,6 +133,9 @@ class TestCopyAnchorsAllAnchorSelection(unittest.TestCase):
              patch('anchors.get_fully_qualified_node_name', side_effect=lambda n: n.name()):
 
             _patch_copy(mock_nuke, [anchor_a, anchor_b], mock_prefs)
+            captured = {}
+            mock_nuke.nodeCopy.side_effect = lambda *a, **k: captured.update(
+                a=anchor_a[KNOB_NAME].getText(), b=anchor_b[KNOB_NAME].getText())
 
             from anchors import copy_anchors
             copy_anchors()
@@ -141,9 +144,13 @@ class TestCopyAnchorsAllAnchorSelection(unittest.TestCase):
         self.assertEqual(knobs_added.get(anchor_a.name()), 'link')
         self.assertEqual(knobs_added.get(anchor_b.name()), 'link')
 
-        # KNOB_NAME should be set to each anchor's own FQNN
-        self.assertEqual(anchor_a[KNOB_NAME].getText(), anchor_a.name())
-        self.assertEqual(anchor_b[KNOB_NAME].getText(), anchor_b.name())
+        # The clipboard copy carries each anchor's own FQNN in KNOB_NAME...
+        self.assertEqual(captured['a'], anchor_a.name())
+        self.assertEqual(captured['b'], anchor_b.name())
+        # ...while the live originals are restored (the stamp would otherwise leave
+        # them looking like stale links — issue #56 non-destructive copy).
+        self.assertNotIn(KNOB_NAME, anchor_a.knobs())
+        self.assertNotIn(KNOB_NAME, anchor_b.knobs())
 
     def test_all_anchor_selection_single_anchor_is_stamped(self):
         """A single anchor in the selection should also be stamped."""
@@ -165,12 +172,20 @@ class TestCopyAnchorsAllAnchorSelection(unittest.TestCase):
              patch('anchors.get_fully_qualified_node_name', side_effect=lambda n: n.name()):
 
             _patch_copy(mock_nuke, [anchor], mock_prefs)
+            captured = {}
+            mock_nuke.nodeCopy.side_effect = lambda *a, **k: captured.update(
+                fqnn=anchor[KNOB_NAME].getText(),
+                dot_type=anchor[DOT_TYPE_KNOB_NAME].getValue())
 
             from anchors import copy_anchors
             copy_anchors()
 
-        self.assertEqual(anchor[KNOB_NAME].getText(), anchor.name())
-        self.assertEqual(anchor[DOT_TYPE_KNOB_NAME].getValue(), 'link')
+        # The clipboard copy carries the anchor's own FQNN and dot_type='link'...
+        self.assertEqual(captured['fqnn'], anchor.name())
+        self.assertEqual(captured['dot_type'], 'link')
+        # ...while the live original is restored (issue #56 non-destructive copy).
+        self.assertNotIn(KNOB_NAME, anchor.knobs())
+        self.assertNotIn(DOT_TYPE_KNOB_NAME, anchor.knobs())
 
 
 class TestCopyAnchorsMixedSelection(unittest.TestCase):
@@ -225,12 +240,17 @@ class TestCopyAnchorsMixedSelection(unittest.TestCase):
              patch('anchors.is_anchor', side_effect=lambda n: n.name().startswith(ANCHOR_PREFIX)):
 
             _patch_copy(mock_nuke, [stale_anchor, plain], mock_prefs)
+            captured = {}
+            mock_nuke.nodeCopy.side_effect = \
+                lambda *a, **k: captured.update(fqnn=stale_anchor[KNOB_NAME].getValue())
 
             from anchors import copy_anchors
             copy_anchors()
 
-        # Stale KNOB_NAME must have been cleared
-        self.assertEqual(stale_anchor[KNOB_NAME].getValue(), '')
+        # The clipboard copy carries no spurious reference (KNOB_NAME cleared)...
+        self.assertEqual(captured['fqnn'], '')
+        # ...while the live original is left untouched (issue #56 non-destructive copy).
+        self.assertEqual(stale_anchor[KNOB_NAME].getValue(), 'OldScript.Anchor_Foo')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_copy_link_node.py
+++ b/tests/test_copy_link_node.py
@@ -116,13 +116,16 @@ class TestCopyLinkNodePathL(unittest.TestCase):
         mock_setup.assert_called_once_with(anchor, noop_link)
 
     def test_copy_local_dot_restores_local_appearance(self):
-        """Copying a Local Dot (input is a plain node NOT in the selection) calls
-        setup_link_node then restores Local label, LOCAL_DOT_COLOR, and dot_type='local'."""
+        """Copying a Local Dot (input is a plain node NOT in the selection) stamps the
+        Local label, LOCAL_DOT_COLOR, and dot_type='local' onto the clipboard copy,
+        then restores the live original (issue #56 — copy is non-destructive)."""
         from constants import DOT_TYPE_KNOB_NAME, LOCAL_DOT_COLOR
         plain = _make_plain_node('Merge1')
         plain.knobs()['label']._value = 'my merge'
         local_dot = _make_link_node(stored_fqnn='Merge1', node_class='Dot', name='Dot1')
         local_dot._input = plain
+
+        captured = {}
 
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts'), \
@@ -133,20 +136,35 @@ class TestCopyLinkNodePathL(unittest.TestCase):
 
             _patch_copy(mock_nuke, [local_dot], mock_prefs)
             mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
+            mock_nuke.nodeCopy.side_effect = lambda *a, **k: captured.update(
+                label=local_dot['label'].getValue(),
+                tile_color=local_dot['tile_color'].getValue(),
+                has_dot_type=DOT_TYPE_KNOB_NAME in local_dot.knobs(),
+                dot_type=(local_dot[DOT_TYPE_KNOB_NAME].getValue()
+                          if DOT_TYPE_KNOB_NAME in local_dot.knobs() else None),
+            )
 
             from anchors import copy_anchors
             copy_anchors()
 
         mock_setup.assert_called_once_with(plain, local_dot)
-        self.assertEqual(local_dot['label'].getValue(), 'Local: my merge')
-        self.assertEqual(local_dot['tile_color'].getValue(), LOCAL_DOT_COLOR)
-        self.assertIn(DOT_TYPE_KNOB_NAME, local_dot.knobs())
-        self.assertEqual(local_dot[DOT_TYPE_KNOB_NAME].getValue(), 'local')
+        # Clipboard copy carries the Local stamp...
+        self.assertEqual(captured['label'], 'Local: my merge')
+        self.assertEqual(captured['tile_color'], LOCAL_DOT_COLOR)
+        self.assertTrue(captured['has_dot_type'])
+        self.assertEqual(captured['dot_type'], 'local')
+        # ...while the live original is restored to its pre-copy state.
+        self.assertEqual(local_dot['label'].getValue(), 'Link: Foo')
+        self.assertEqual(local_dot['tile_color'].getValue(), 0)
+        self.assertNotIn(DOT_TYPE_KNOB_NAME, local_dot.knobs())
 
     def test_copy_link_dot_no_input_stamps_empty_fqnn(self):
-        """Copying a disconnected link node (input(0)=None) stamps KNOB_NAME=""."""
+        """Copying a disconnected link node (input(0)=None) stamps KNOB_NAME="" onto the
+        clipboard copy, then restores the original's KNOB_NAME (issue #56)."""
         link_dot = _make_link_node(stored_fqnn='Anchor_Foo', node_class='Dot')
         link_dot._input = None
+
+        captured = {}
 
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts'), \
@@ -156,19 +174,26 @@ class TestCopyLinkNodePathL(unittest.TestCase):
              patch('anchors.setup_link_node') as mock_setup:
 
             _patch_copy(mock_nuke, [link_dot], mock_prefs)
+            mock_nuke.nodeCopy.side_effect = \
+                lambda *a, **k: captured.update(fqnn=link_dot[KNOB_NAME].getText())
 
             from anchors import copy_anchors
             copy_anchors()
 
         mock_setup.assert_not_called()
-        self.assertEqual(link_dot[KNOB_NAME].getText(), "")
+        self.assertEqual(captured['fqnn'], "")
+        self.assertEqual(link_dot[KNOB_NAME].getText(), 'Anchor_Foo',
+                         "Live original KNOB_NAME must be restored after copy")
 
     def test_copy_link_dot_input_in_selection_stamps_empty_fqnn(self):
         """When a Link Dot and its anchor are both in the selection, KNOB_NAME is
-        stamped to "" so paste can re-setup from the pasted anchor copy."""
+        stamped to "" on the clipboard copy so paste can re-setup from the pasted
+        anchor copy; the live original is then restored (issue #56)."""
         anchor = _make_anchor_node('Anchor_Foo')
         link_dot = _make_link_node(stored_fqnn='Anchor_Foo', node_class='Dot')
         link_dot._input = anchor
+
+        captured = {}
 
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts'), \
@@ -179,12 +204,16 @@ class TestCopyLinkNodePathL(unittest.TestCase):
 
             # Both nodes in selection — anchor is input_node and also in selected_nodes.
             _patch_copy(mock_nuke, [link_dot, anchor], mock_prefs)
+            mock_nuke.nodeCopy.side_effect = \
+                lambda *a, **k: captured.update(fqnn=link_dot[KNOB_NAME].getText())
 
             from anchors import copy_anchors
             copy_anchors()
 
         mock_setup.assert_not_called()
-        self.assertEqual(link_dot[KNOB_NAME].getText(), "")
+        self.assertEqual(captured['fqnn'], "")
+        self.assertEqual(link_dot[KNOB_NAME].getText(), 'Anchor_Foo',
+                         "Live original KNOB_NAME must be restored after copy")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dot_type_distinction.py
+++ b/tests/test_dot_type_distinction.py
@@ -244,12 +244,15 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
             mock_add_input_knob.assert_called_once_with(dot_node, dot_type='link')
 
     def test_copy_hidden_anchor_backed_dot_sets_tile_color_to_anchor_default_color(self):
-        """copy_anchors() on anchor-backed Dot must set tile_color to ANCHOR_DEFAULT_COLOR."""
+        """copy_anchors() on anchor-backed Dot must stamp tile_color ANCHOR_DEFAULT_COLOR
+        onto the clipboard copy, while leaving the live original unchanged (issue #56)."""
         from constants import ANCHOR_DEFAULT_COLOR
 
         dot_node = self._make_dot_node_with_hide_input()
         anchor_input_node = _make_stub_node(name='Anchor_MyFootage', node_class='NoOp')
         dot_node._input = anchor_input_node
+
+        captured = {}
 
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
@@ -261,14 +264,21 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
                    return_value='sourceScript.Anchor_MyFootage'):
 
             mock_nuke.selectedNodes.return_value = [dot_node]
+            # Capture the stamped state at the moment it is serialised to the clipboard.
+            mock_nuke.nodeCopy.side_effect = \
+                lambda *a, **k: captured.update(tile_color=dot_node['tile_color'].getValue())
 
             from anchors import copy_anchors
             copy_anchors()
 
             self.assertEqual(
-                dot_node['tile_color'].getValue(),
+                captured['tile_color'],
                 ANCHOR_DEFAULT_COLOR,
-                "Anchor-backed Dot tile_color must be set to ANCHOR_DEFAULT_COLOR (canonical purple)"
+                "Anchor-backed Dot tile_color on the clipboard copy must be ANCHOR_DEFAULT_COLOR (canonical purple)"
+            )
+            self.assertEqual(
+                dot_node['tile_color'].getValue(), 0,
+                "Live original tile_color must be restored after copy (non-destructive)"
             )
 
     def test_copy_hidden_plain_node_backed_dot_calls_add_input_knob_with_dot_type_local(self):
@@ -296,11 +306,14 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
             mock_add_input_knob.assert_called_once_with(dot_node, dot_type='local')
 
     def test_copy_hidden_plain_node_backed_dot_sets_label_to_local_prefix(self):
-        """copy_anchors() on plain-node-backed Dot must set label to 'Local: {source name}'."""
+        """copy_anchors() on plain-node-backed Dot must stamp label 'Local: {source name}'
+        onto the clipboard copy, while leaving the live original unchanged (issue #56)."""
         dot_node = self._make_dot_node_with_hide_input()
         plain_input_node = _make_stub_node(name='Blur1', node_class='Blur',
                                            knobs_dict={'label': _make_knob('')})
         dot_node._input = plain_input_node
+
+        captured = {}
 
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
@@ -313,18 +326,25 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
 
             mock_nuke.selectedNodes.return_value = [dot_node]
             mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
+            mock_nuke.nodeCopy.side_effect = \
+                lambda *a, **k: captured.update(label=dot_node['label'].getValue())
 
             from anchors import copy_anchors
             copy_anchors()
 
             self.assertEqual(
-                dot_node['label'].getValue(),
+                captured['label'],
                 'Local: Blur1',
-                "Plain-node-backed Dot label must be set to 'Local: {source name}'"
+                "Plain-node-backed Dot label on the clipboard copy must be 'Local: {source name}'"
+            )
+            self.assertEqual(
+                dot_node['label'].getValue(), '',
+                "Live original label must be restored after copy (non-destructive)"
             )
 
     def test_copy_hidden_plain_node_backed_dot_sets_tile_color_to_local_dot_color(self):
-        """copy_anchors() on plain-node-backed Dot must set tile_color to LOCAL_DOT_COLOR."""
+        """copy_anchors() on plain-node-backed Dot must stamp tile_color LOCAL_DOT_COLOR
+        onto the clipboard copy, while leaving the live original unchanged (issue #56)."""
         from constants import LOCAL_DOT_COLOR
 
         dot_node = self._make_dot_node_with_hide_input()
@@ -332,6 +352,8 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
                                            knobs_dict={'label': _make_knob('')})
         dot_node._input = plain_input_node
 
+        captured = {}
+
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
              patch('anchors.is_link', return_value=False), \
@@ -343,19 +365,26 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
 
             mock_nuke.selectedNodes.return_value = [dot_node]
             mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
+            mock_nuke.nodeCopy.side_effect = \
+                lambda *a, **k: captured.update(tile_color=dot_node['tile_color'].getValue())
 
             from anchors import copy_anchors
             copy_anchors()
 
             self.assertEqual(
-                dot_node['tile_color'].getValue(),
+                captured['tile_color'],
                 LOCAL_DOT_COLOR,
-                "Plain-node-backed Dot tile_color must be set to LOCAL_DOT_COLOR (burnt orange)"
+                "Plain-node-backed Dot tile_color on the clipboard copy must be LOCAL_DOT_COLOR (burnt orange)"
+            )
+            self.assertEqual(
+                dot_node['tile_color'].getValue(), 0,
+                "Live original tile_color must be restored after copy (non-destructive)"
             )
 
     def test_copy_hidden_plain_node_backed_dot_stores_script_qualified_fqnn(self):
-        """copy_anchors() on plain-node-backed Dot must store 'scriptStem.nodeFullName'
-        in KNOB_NAME so that paste can enforce the same-script guard."""
+        """copy_anchors() on plain-node-backed Dot must stamp 'scriptStem.nodeFullName'
+        into KNOB_NAME on the clipboard copy (so paste can enforce the same-script
+        guard), while leaving the live original unchanged (issue #56)."""
         from constants import KNOB_NAME
 
         dot_node = self._make_dot_node_with_hide_input()
@@ -363,6 +392,8 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
                                            knobs_dict={'label': _make_knob('')})
         dot_node._input = plain_input_node
 
+        captured = {}
+
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
              patch('anchors.is_link', return_value=False), \
@@ -374,14 +405,20 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
 
             mock_nuke.selectedNodes.return_value = [dot_node]
             mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
+            mock_nuke.nodeCopy.side_effect = \
+                lambda *a, **k: captured.update(fqnn=dot_node[KNOB_NAME].getText())
 
             from anchors import copy_anchors
             copy_anchors()
 
             self.assertEqual(
-                dot_node[KNOB_NAME].getValue(),
+                captured['fqnn'],
                 'sourceScript.Blur1',
-                "Local Dot KNOB_NAME must be 'scriptStem.nodeFullName' after copy"
+                "Local Dot KNOB_NAME on the clipboard copy must be 'scriptStem.nodeFullName'"
+            )
+            self.assertEqual(
+                dot_node[KNOB_NAME].getText(), '',
+                "Live original KNOB_NAME must be restored after copy (non-destructive)"
             )
 
 

--- a/tests/test_issue27.py
+++ b/tests/test_issue27.py
@@ -252,15 +252,20 @@ class TestCopyAnchorsDoesNotStampFqnnOnAnchors(unittest.TestCase):
 
             mock_nuke.selectedNodes.return_value = [anchor, non_anchor]
             mock_nuke.allNodes.return_value = []
+            captured = {}
+            mock_nuke.nodeCopy.side_effect = \
+                lambda *a, **k: captured.update(fqnn=anchor[KNOB_NAME].getText())
 
             from anchors import copy_anchors
             copy_anchors()
 
         self.assertEqual(
-            anchor[KNOB_NAME].getText(), '',
-            "Expected KNOB_NAME cleared to '' after copy_anchors in mixed selection, "
-            f"but got '{anchor[KNOB_NAME].getText()}'",
+            captured['fqnn'], '',
+            "Expected KNOB_NAME cleared to '' on the clipboard copy in mixed selection, "
+            f"but got '{captured['fqnn']}'",
         )
+        # Live original is left untouched — copy is non-destructive (issue #56).
+        self.assertEqual(anchor[KNOB_NAME].getText(), 'oldScript.Anchor_Foo')
 
     def test_group_qualified_anchor_pasted_cross_script_stays_as_anchor(self):
         """A Group-qualified anchor pasted cross-script must not be replaced with a link.

--- a/tests/test_issue56_nondestructive_copy.py
+++ b/tests/test_issue56_nondestructive_copy.py
@@ -1,0 +1,182 @@
+"""Regression tests for issue #56 — copy_anchors() must be non-destructive.
+
+Before the fix, copy_anchors() stamped the live selected nodes in the DAG before
+nuke.nodeCopy(), so the act of copying changed a node's label/colour/knobs.  After
+an undo this left nodes in an inconsistent state, and the next copy turned a dot
+into a brown "Local: …" dot.  The stamps must reach only the clipboard; the live
+originals must be left exactly as the user left them.
+
+A faithful fake add_input_knob adds the same knobs the real one would (TAB,
+KNOB_NAME, DOT_TYPE, reconnect), so the knobs added during stamping are genuinely
+added and then genuinely removed on restore — proving no knob drift accumulates
+across repeated copies, without depending on global stub state set by other tests.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from constants import (
+    DOT_TYPE_KNOB_NAME,
+    KNOB_NAME,
+    LINK_RECONNECT_KNOB_NAME,
+    LOCAL_DOT_COLOR,
+    TAB_NAME,
+)
+from tests.stubs import StubKnob, StubNode
+
+
+def _make_knob(value='', knob_name=''):
+    return StubKnob(value=value, knob_name=knob_name)
+
+
+class _IntKnob:
+    """Mimics a Nuke integer knob (e.g. tile_color): getValue() returns a float,
+    but setValue() rejects a float — it must be given an int."""
+
+    def __init__(self, value, knob_name=''):
+        self._value = value
+        self._knob_name = knob_name
+
+    def name(self):
+        return self._knob_name
+
+    def getValue(self):
+        return float(self._value)
+
+    def value(self):
+        return self._value
+
+    def setValue(self, new_value):
+        if isinstance(new_value, float):
+            raise TypeError("'float' object cannot be interpreted as an integer")
+        self._value = new_value
+
+
+def _fake_add_input_knob(node, dot_type=None):
+    """Mirror link.add_input_knob: (re)add the custom knobs as real named stubs."""
+    node._knobs[LINK_RECONNECT_KNOB_NAME] = StubKnob(knob_name=LINK_RECONNECT_KNOB_NAME)
+    node._knobs[TAB_NAME] = StubKnob(knob_name=TAB_NAME)
+    node._knobs[KNOB_NAME] = StubKnob(knob_name=KNOB_NAME)
+    if dot_type is not None:
+        node._knobs[DOT_TYPE_KNOB_NAME] = StubKnob(dot_type, knob_name=DOT_TYPE_KNOB_NAME)
+
+
+def _make_local_dot():
+    """A Dot that is already a Local-style link (has KNOB_NAME) wired to a plain node."""
+    dot = StubNode(name='Dot1', node_class='Dot', knobs_dict={
+        KNOB_NAME: _make_knob('Merge1', knob_name=KNOB_NAME),
+        'label': _make_knob('Link: Foo'),
+        'tile_color': _make_knob(0),
+        'hide_input': _make_knob(True, knob_name='hide_input'),
+        'note_font_size': _make_knob(0),
+        'selected': _make_knob(False),
+    })
+    plain = StubNode(name='Merge1', node_class='Merge',
+                     knobs_dict={'label': _make_knob('my merge')})
+    dot._input = plain
+    return dot, plain
+
+
+def _snapshot(dot):
+    """Capture the observable state of *dot* for before/after comparison."""
+    return {
+        'knob_names': set(dot.knobs()),
+        'label': dot['label'].getValue(),
+        'tile_color': dot['tile_color'].getValue(),
+        'fqnn': dot[KNOB_NAME].getText() if KNOB_NAME in dot.knobs() else None,
+    }
+
+
+class TestIssue56NonDestructiveCopy(unittest.TestCase):
+
+    def test_copy_does_not_mutate_original(self):
+        """A single copy leaves the original byte-for-byte unchanged while the
+        clipboard copy carries the Local stamp."""
+        dot, plain = _make_local_dot()
+        before = _snapshot(dot)
+        captured = {}
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node'), \
+             patch('anchors.add_input_knob', side_effect=_fake_add_input_knob):
+
+            mock_prefs.plugin_enabled = True
+            mock_nuke.selectedNodes.return_value = [dot]
+            mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
+            mock_nuke.nodeCopy.side_effect = lambda *a, **k: captured.update(
+                label=dot['label'].getValue(),
+                tile_color=dot['tile_color'].getValue(),
+                dot_type=(dot[DOT_TYPE_KNOB_NAME].getValue()
+                          if DOT_TYPE_KNOB_NAME in dot.knobs() else None),
+            )
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+        # Clipboard copy was stamped...
+        self.assertEqual(captured['label'], 'Local: my merge')
+        self.assertEqual(captured['tile_color'], LOCAL_DOT_COLOR)
+        self.assertEqual(captured['dot_type'], 'local')
+        # ...the live original is fully restored, including no leftover knobs.
+        self.assertEqual(_snapshot(dot), before)
+        self.assertNotIn(TAB_NAME, dot.knobs())
+        self.assertNotIn(DOT_TYPE_KNOB_NAME, dot.knobs())
+
+    def test_repeated_copy_never_drifts(self):
+        """Issue #56 scenario proxy: copying the same node many times must never
+        accumulate state — the dot never becomes a persisted brown 'Local:' dot."""
+        dot, plain = _make_local_dot()
+        before = _snapshot(dot)
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node'), \
+             patch('anchors.add_input_knob', side_effect=_fake_add_input_knob):
+
+            mock_prefs.plugin_enabled = True
+            mock_nuke.selectedNodes.return_value = [dot]
+            mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
+
+            from anchors import copy_anchors
+            for _ in range(5):
+                copy_anchors()
+                self.assertEqual(
+                    _snapshot(dot), before,
+                    "Repeated copy must not mutate the original (issue #56)",
+                )
+                self.assertNotEqual(dot['tile_color'].getValue(), LOCAL_DOT_COLOR,
+                                    "Original must never persist as a brown Local dot")
+
+
+class TestRestoreIntegerKnob(unittest.TestCase):
+    """Issue #56 follow-up: integer knobs (tile_color) return a float from
+    getValue() but require an int on setValue(); restore must cast."""
+
+    def test_restore_casts_float_to_int_for_integer_knobs(self):
+        from anchors import _snapshot_node_state, _restore_node_state
+
+        node = StubNode(name='Dot1', node_class='Dot', knobs_dict={
+            'tile_color': _IntKnob(0, knob_name='tile_color'),
+            'label': _make_knob('orig'),
+        })
+        snapshot = _snapshot_node_state(node)
+
+        # Stamp-like mutation, then restore.
+        node['tile_color'].setValue(0x7A3A00FF)
+        node['label'].setValue('Local: changed')
+        _restore_node_state(node, snapshot)
+
+        self.assertEqual(node['tile_color'].value(), 0,
+                         "tile_color must be restored (cast back to int)")
+        self.assertEqual(node['label'].getValue(), 'orig')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_toggle_input_visibility.py
+++ b/tests/test_toggle_input_visibility.py
@@ -1,0 +1,228 @@
+"""Tests for toggle_input_visibility() — the wrapper around Nuke's
+Edit > Node > Input On/Off (Alt+H).
+
+Hiding a wired Dot's input is the deliberate "manual link" gesture that converts
+the Dot into a Local/Link dot in place.  This replaces the old behaviour where
+the conversion was a side effect of copy_anchors() stamping the original, which
+caused issue #56 (copying alone mutated nodes in the DAG).
+"""
+
+import unittest
+from unittest.mock import patch
+
+from constants import (
+    ANCHOR_DEFAULT_COLOR,
+    DOT_TYPE_KNOB_NAME,
+    KNOB_NAME,
+    LINK_RECONNECT_KNOB_NAME,
+    LOCAL_DOT_COLOR,
+    TAB_NAME,
+)
+from tests.stubs import StubKnob, StubNode
+
+
+def _make_knob(value='', knob_name=''):
+    return StubKnob(value=value, knob_name=knob_name)
+
+
+def _make_dot(name='Dot1', hide_input=False, node_class='Dot'):
+    """A Dot with the knobs the wrapper and stamping helpers touch."""
+    return StubNode(name=name, node_class=node_class, knobs_dict={
+        'hide_input': _make_knob(hide_input, knob_name='hide_input'),
+        'label': _make_knob(''),
+        'tile_color': _make_knob(0),
+        'note_font_size': _make_knob(0),
+        KNOB_NAME: _make_knob('', knob_name=KNOB_NAME),
+    })
+
+
+def _patch_common(mock_nuke, selected, plugin_enabled=True):
+    mock_nuke.selectedNodes.return_value = selected
+    mock_nuke.root.return_value.name.return_value = 'sourceScript.nk'
+
+
+class TestToggleInputVisibility(unittest.TestCase):
+
+    def test_hiding_wired_plain_backed_dot_stamps_local(self):
+        """Hiding a Dot wired to a plain node stamps it as a Local dot in place."""
+        dot = _make_dot(hide_input=False)
+        plain = StubNode(name='Merge1', node_class='Merge',
+                         knobs_dict={'label': _make_knob('my merge')})
+        dot._input = plain
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', return_value=False), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node') as mock_setup, \
+             patch('anchors.add_input_knob') as mock_add_input_knob:
+
+            mock_prefs.plugin_enabled = True
+            _patch_common(mock_nuke, [dot])
+
+            from anchors import toggle_input_visibility
+            toggle_input_visibility()
+
+        # Built-in effect: input is now hidden.
+        self.assertTrue(dot['hide_input'].value())
+        # Stamped as a Local dot.
+        mock_setup.assert_called_once_with(plain, dot)
+        mock_add_input_knob.assert_called_once_with(dot, dot_type='local')
+        self.assertEqual(dot['label'].getValue(), 'Local: my merge')
+        self.assertEqual(dot['tile_color'].getValue(), LOCAL_DOT_COLOR)
+        self.assertEqual(dot[KNOB_NAME].getText(), 'sourceScript.Merge1')
+
+    def test_hiding_wired_anchor_backed_dot_stamps_link(self):
+        """Hiding a Dot wired to an anchor stamps it as a Link dot in place."""
+        dot = _make_dot(hide_input=False)
+        anchor = StubNode(name='Anchor_Foo', node_class='NoOp',
+                          knobs_dict={'label': _make_knob('Foo'), 'tile_color': _make_knob(0)})
+        dot._input = anchor
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', return_value=False), \
+             patch('anchors.is_anchor', side_effect=lambda n: n is anchor), \
+             patch('anchors.setup_link_node') as mock_setup, \
+             patch('anchors.add_input_knob') as mock_add_input_knob:
+
+            mock_prefs.plugin_enabled = True
+            _patch_common(mock_nuke, [dot])
+
+            from anchors import toggle_input_visibility
+            toggle_input_visibility()
+
+        self.assertTrue(dot['hide_input'].value())
+        mock_setup.assert_called_once_with(anchor, dot)
+        mock_add_input_knob.assert_called_once_with(dot, dot_type='link')
+        self.assertEqual(dot['tile_color'].getValue(), ANCHOR_DEFAULT_COLOR)
+
+    def test_hiding_unwired_dot_only_toggles(self):
+        """Hiding a Dot with no input toggles hide_input but does not stamp."""
+        dot = _make_dot(hide_input=False)
+        dot._input = None
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', return_value=False), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node') as mock_setup, \
+             patch('anchors.add_input_knob') as mock_add_input_knob:
+
+            mock_prefs.plugin_enabled = True
+            _patch_common(mock_nuke, [dot])
+
+            from anchors import toggle_input_visibility
+            toggle_input_visibility()
+
+        self.assertTrue(dot['hide_input'].value())
+        mock_setup.assert_not_called()
+        mock_add_input_knob.assert_not_called()
+        self.assertNotIn(DOT_TYPE_KNOB_NAME, dot.knobs())
+
+    def test_already_marked_dot_is_not_restamped(self):
+        """Hiding an already-marked (link) Dot must not re-stamp it."""
+        dot = _make_dot(hide_input=False)
+        plain = StubNode(name='Merge1', node_class='Merge',
+                         knobs_dict={'label': _make_knob('m')})
+        dot._input = plain
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', return_value=True), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node') as mock_setup, \
+             patch('anchors.add_input_knob') as mock_add_input_knob:
+
+            mock_prefs.plugin_enabled = True
+            _patch_common(mock_nuke, [dot])
+
+            from anchors import toggle_input_visibility
+            toggle_input_visibility()
+
+        self.assertTrue(dot['hide_input'].value())
+        mock_setup.assert_not_called()
+        mock_add_input_knob.assert_not_called()
+
+    def test_plugin_disabled_toggles_but_does_not_stamp(self):
+        """When the plugin is disabled the built-in toggle still runs, but no stamping."""
+        dot = _make_dot(hide_input=False)
+        plain = StubNode(name='Merge1', node_class='Merge',
+                         knobs_dict={'label': _make_knob('m')})
+        dot._input = plain
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', return_value=False), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node') as mock_setup, \
+             patch('anchors.add_input_knob') as mock_add_input_knob:
+
+            mock_prefs.plugin_enabled = False
+            _patch_common(mock_nuke, [dot])
+
+            from anchors import toggle_input_visibility
+            toggle_input_visibility()
+
+        self.assertTrue(dot['hide_input'].value())
+        mock_setup.assert_not_called()
+        mock_add_input_knob.assert_not_called()
+
+    def test_unhiding_unmarked_dot_does_not_stamp(self):
+        """Toggling a currently-hidden, unmarked Dot back to visible must not stamp it."""
+        dot = _make_dot(hide_input=True)
+        plain = StubNode(name='Merge1', node_class='Merge',
+                         knobs_dict={'label': _make_knob('m')})
+        dot._input = plain
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', return_value=False), \
+             patch('anchors.is_anchor', return_value=False), \
+             patch('anchors.setup_link_node') as mock_setup, \
+             patch('anchors.add_input_knob') as mock_add_input_knob:
+
+            mock_prefs.plugin_enabled = True
+            _patch_common(mock_nuke, [dot])
+
+            from anchors import toggle_input_visibility
+            toggle_input_visibility()
+
+        # hide_input toggled True -> False; no stamping because it was just revealed.
+        self.assertFalse(dot['hide_input'].value())
+        mock_setup.assert_not_called()
+        mock_add_input_knob.assert_not_called()
+
+    def test_unhiding_marked_dot_clears_link_state(self):
+        """Revealing the input of a Local/Link dot reverts it to a plain node."""
+        dot = StubNode(name='Dot1', node_class='Dot', knobs_dict={
+            KNOB_NAME: _make_knob('sourceScript.Merge1', knob_name=KNOB_NAME),
+            DOT_TYPE_KNOB_NAME: _make_knob('local', knob_name=DOT_TYPE_KNOB_NAME),
+            TAB_NAME: _make_knob('', knob_name=TAB_NAME),
+            LINK_RECONNECT_KNOB_NAME: _make_knob('', knob_name=LINK_RECONNECT_KNOB_NAME),
+            'label': _make_knob('Local: my merge'),
+            'tile_color': _make_knob(LOCAL_DOT_COLOR),
+            'hide_input': _make_knob(True, knob_name='hide_input'),
+            'note_font_size': _make_knob(0),
+        })
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', return_value=False):
+
+            mock_prefs.plugin_enabled = True
+            _patch_common(mock_nuke, [dot])
+
+            from anchors import toggle_input_visibility
+            toggle_input_visibility()
+
+        self.assertFalse(dot['hide_input'].value())
+        for knob_name in (KNOB_NAME, DOT_TYPE_KNOB_NAME, TAB_NAME, LINK_RECONNECT_KNOB_NAME):
+            self.assertNotIn(knob_name, dot.knobs())
+        self.assertEqual(dot['label'].getValue(), '')
+        self.assertEqual(dot['tile_color'].getValue(), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #56.

## Problem
`copy_anchors()` (bound to Ctrl+C) stamped the **live** selected nodes in the DAG before `nuke.nodeCopy()`, so the act of copying mutated a node's label, tile colour and knobs. After an accidental undo this left a node in an inconsistent state, and the next copy re-routed it down the local-dot branch — turning it into a brown `Local: …` dot. The reporter's clue ("the action of copy makes the bug appear, no need to paste") was the signature of in-place mutation on copy.

## Fix
- **Non-destructive copy:** snapshot each selected node, run the existing stamping (so the clipboard still carries the correct payload), `nodeCopy()`, then restore the live originals. Integer knobs (`tile_color`) return a float from `getValue()` but require an int on `setValue()`, so restore casts on `TypeError`.
- **Preserve the manual-link workflow on a deliberate trigger:** the conversion that used to be a copy side effect now happens when you hide an input. The built-in **Edit ▸ Node ▸ Input On/Off (Alt+H)** is wrapped — hiding a wired Dot's input converts it to a Local/Link dot in place, and revealing the input again clears the link state. This follows the existing pattern used to override Copy/Cut/Paste (no callbacks).
- **Clear Link State command:** new **Anchors ▸ Clear Link State** menu item reverts a Local/Link dot to a plain node (strips the custom knobs, clears the label/colour, reveals the input) without toggling visibility.

## Tests
- Reframed the copy tests that asserted the old buggy "original keeps the stamp" contract to instead verify the stamp reaches the **clipboard** while the live original is **restored**.
- New regression coverage: non-destructive copy + repeated-copy invariant, integer-knob restore, the Input On/Off wrapper (convert on hide, clear on reveal), and Clear Link State.
- Stub fixes so restore is observable: `removeKnob` now actually deletes; `PyScript_Knob` is a named stub.
- **472 tests pass** (also enforced by the pre-commit hook).

## Manual verification (in Nuke)
- Copy a dot → the original is visually unchanged; copy → paste → Ctrl+Z → Ctrl+C no longer produces a brown `Local: …` dot.
- Dot → wire → Alt+H becomes a Local/Link dot; Alt+H again reverts it; Clear Link State reverts without changing visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)