### PR TITLE
fix: paste hidden-input anchors as anchors, not Local/Link dots (#55)

### DIFF
--- a/anchors.py
+++ b/anchors.py
@@ -172,6 +172,10 @@ def _stamp_for_anchor(node, selection_is_all_anchors, cut):
         # back to the original anchor.  Skip when cutting: the originals will be
         # deleted, so paste can never resolve them and would leave the pasted
         # copies with stale link knobs.
+        # Issue #55 confirmed this paste-as-link behaviour is desired, not a
+        # misfeature: copying a selection of only anchors and pasting Links is
+        # intentional.  Only the hidden-input misclassification (scenarios C/D)
+        # was a bug; this path is deliberately preserved.
         add_input_knob(node, dot_type='link')
         node[KNOB_NAME].setText(get_fully_qualified_node_name(node))
     elif is_link(node):
@@ -203,12 +207,17 @@ def copy_anchors(cut=False):
         # cause of issue #56, where copying alone mutated the node in the DAG.
         snapshots = {node: _snapshot_node_state(node) for node in selected_nodes}
         for node in selected_nodes:
+            # is_anchor() is checked before the hidden-input-dot branch because
+            # anchors are NoOp/Dot nodes — both in HIDDEN_INPUT_CLASSES.  An anchor
+            # whose input wire is hidden (routine after Alt+H, or for Dot anchors)
+            # must be stamped as an anchor, never misrouted into _stamp_for_hidden_dot
+            # and turned into a Local/Link dot (issue #55, scenarios C and D).
             if is_link(node) and not is_anchor(node):
                 _stamp_for_link(node, selected_nodes, script_stem)
-            elif node.Class() in HIDDEN_INPUT_CLASSES and node['hide_input'].getValue():
-                _stamp_for_hidden_dot(node, selected_nodes, script_stem)
             elif is_anchor(node):
                 _stamp_for_anchor(node, selection_is_all_anchors, cut)
+            elif node.Class() in HIDDEN_INPUT_CLASSES and node['hide_input'].getValue():
+                _stamp_for_hidden_dot(node, selected_nodes, script_stem)
 
         # now that we've stored the info we need on the nodes, do a regular copy
         nuke.nodeCopy(nukescripts.cut_paste_file())
@@ -503,7 +512,11 @@ def paste_anchors():
                   and DOT_TYPE_KNOB_NAME in node.knobs()
                   and node[DOT_TYPE_KNOB_NAME].getValue() == 'link'):
                 _handle_pasted_anchor_as_link(node, final_selection)
-            elif node.Class() in HIDDEN_INPUT_CLASSES:
+            elif node.Class() in HIDDEN_INPUT_CLASSES and not is_anchor(node):
+                # `not is_anchor(node)` is a defensive, symmetric counterpart to the
+                # copy-loop ordering: an anchor must never enter the hidden-input
+                # reconnect path and be turned into a Local/Link dot.  Guards against
+                # stale clipboards stamped by the pre-issue-#55 code.
                 _handle_pasted_hidden_input(node)
 
         # it's possible we changed selection, reset it

--- a/tests/test_dot_type_distinction.py
+++ b/tests/test_dot_type_distinction.py
@@ -228,10 +228,10 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
         dot_node._input = anchor_input_node
 
         with patch('anchors.nuke') as mock_nuke, \
-             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.nukescripts'), \
              patch('anchors.is_link', return_value=False), \
-             patch('anchors.is_anchor', side_effect=lambda n: n is anchor_input_node) as mock_is_anchor, \
-             patch('anchors.setup_link_node') as mock_setup_link_node, \
+             patch('anchors.is_anchor', side_effect=lambda n: n is anchor_input_node), \
+             patch('anchors.setup_link_node'), \
              patch('anchors.add_input_knob') as mock_add_input_knob, \
              patch('anchors.get_fully_qualified_node_name',
                    return_value='sourceScript.Anchor_MyFootage'):
@@ -255,7 +255,7 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
         captured = {}
 
         with patch('anchors.nuke') as mock_nuke, \
-             patch('anchors.nukescripts') as mock_nukescripts, \
+             patch('anchors.nukescripts'), \
              patch('anchors.is_link', return_value=False), \
              patch('anchors.is_anchor', side_effect=lambda n: n is anchor_input_node), \
              patch('anchors.setup_link_node'), \

--- a/tests/test_dot_type_distinction.py
+++ b/tests/test_dot_type_distinction.py
@@ -230,7 +230,7 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
              patch('anchors.is_link', return_value=False), \
-             patch('anchors.is_anchor', return_value=True) as mock_is_anchor, \
+             patch('anchors.is_anchor', side_effect=lambda n: n is anchor_input_node) as mock_is_anchor, \
              patch('anchors.setup_link_node') as mock_setup_link_node, \
              patch('anchors.add_input_knob') as mock_add_input_knob, \
              patch('anchors.get_fully_qualified_node_name',
@@ -257,7 +257,7 @@ class TestCopyHiddenDotTypeBehavior(unittest.TestCase):
         with patch('anchors.nuke') as mock_nuke, \
              patch('anchors.nukescripts') as mock_nukescripts, \
              patch('anchors.is_link', return_value=False), \
-             patch('anchors.is_anchor', return_value=True), \
+             patch('anchors.is_anchor', side_effect=lambda n: n is anchor_input_node), \
              patch('anchors.setup_link_node'), \
              patch('anchors.add_input_knob'), \
              patch('anchors.get_fully_qualified_node_name',

--- a/tests/test_issue55_anchor_paste.py
+++ b/tests/test_issue55_anchor_paste.py
@@ -1,0 +1,232 @@
+"""Tests for Issue #55: copy-pasting an Anchor must paste an Anchor unchanged
+when the anchor's input wire is hidden.
+
+Root cause fixed: the copy/paste dispatch chains classified a node as a
+hidden-input Dot (NoOp/Dot are both in HIDDEN_INPUT_CLASSES) *before* checking
+is_anchor().  An anchor whose input was hidden (routine after Alt+H, or for Dot
+anchors) was therefore misrouted into the hidden-dot path and stamped /
+reconnected as a Local/Link dot.
+
+Covers:
+- Scenario C: anchor (hide_input=True) + its plain input → anchor NOT stamped.
+- Scenario D: anchor (hide_input=True) + a Dot input → anchor NOT stamped.
+- Scenario B: anchor (hide_input=True) + a Link → anchor NOT stamped.
+- Paste defensive guard: a pasted anchor carrying a stale KNOB_NAME +
+  DOT_TYPE='local' is left as an anchor (never enters _handle_pasted_hidden_input).
+- Scenario A lock-in: an all-anchor selection still stamps DOT_TYPE='link'
+  (Issue #37) even when the anchor's input is hidden.  This is the *desired*
+  paste-as-link behaviour, NOT a misfeature.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from constants import ANCHOR_PREFIX, DOT_TYPE_KNOB_NAME, KNOB_NAME
+from tests.stubs import StubKnob, StubNode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_knob(value='', knob_name=''):
+    return StubKnob(value=value, knob_name=knob_name)
+
+
+def _make_hidden_input_anchor(name='Anchor_Foo'):
+    """A NoOp anchor whose input wire is hidden (hide_input=True)."""
+    return StubNode(
+        name=name,
+        node_class='NoOp',
+        knobs_dict={
+            'label': _make_knob(''),
+            'tile_color': _make_knob(0),
+            'hide_input': _make_knob(True),
+            'selected': _make_knob(False),
+        },
+    )
+
+
+def _make_plain_node(name='Read1', node_class='Read'):
+    return StubNode(
+        name=name,
+        node_class=node_class,
+        knobs_dict={
+            'label': _make_knob(''),
+            'tile_color': _make_knob(0),
+            'hide_input': _make_knob(False),
+            'selected': _make_knob(False),
+        },
+    )
+
+
+def _make_link_node(name='NoOp1'):
+    """A plain Link node (is_link True via KNOB_NAME, is_anchor False)."""
+    return StubNode(
+        name=name,
+        node_class='NoOp',
+        knobs_dict={
+            KNOB_NAME: _make_knob('', knob_name=KNOB_NAME),
+            'label': _make_knob('Link: Foo'),
+            'tile_color': _make_knob(0),
+            'hide_input': _make_knob(True),
+            'selected': _make_knob(False),
+        },
+    )
+
+
+def _patch_copy(mock_nuke, selected_nodes, prefs_mock):
+    mock_nuke.lastHitGroup.return_value = MagicMock()
+    mock_nuke.selectedNodes.return_value = selected_nodes
+    mock_nuke.nodeCopy.return_value = None
+    mock_nuke.allNodes.return_value = []
+    root_obj = MagicMock()
+    root_obj.name.return_value = 'sourceScript.nk'
+    mock_nuke.root.return_value = root_obj
+    prefs_mock.plugin_enabled = True
+
+
+# ---------------------------------------------------------------------------
+# Scenarios C, D, B — a hidden-input anchor in a mixed selection is NOT stamped
+# ---------------------------------------------------------------------------
+
+class TestHiddenInputAnchorNotMisclassified(unittest.TestCase):
+    """A hidden-input anchor copied alongside other nodes must remain an anchor."""
+
+    def _run_copy_and_collect_stamps(self, anchor, other_node):
+        """Copy [anchor, other_node] and return the list of nodes passed to
+        add_input_knob (i.e. the nodes that got stamped)."""
+        add_input_knob_calls = []
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', side_effect=lambda n: KNOB_NAME in n.knobs()), \
+             patch('anchors.is_anchor', side_effect=lambda n: n.name().startswith(ANCHOR_PREFIX)), \
+             patch('anchors.add_input_knob',
+                   side_effect=lambda n, **kw: add_input_knob_calls.append(n)), \
+             patch('anchors.setup_link_node'), \
+             patch('anchors.get_fully_qualified_node_name', side_effect=lambda n: n.name()):
+
+            _patch_copy(mock_nuke, [anchor, other_node], mock_prefs)
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+        return add_input_knob_calls
+
+    def test_scenario_c_anchor_with_plain_input_is_not_stamped(self):
+        """Scenario C: anchor (hidden input) + its plain input → anchor unstamped."""
+        anchor = _make_hidden_input_anchor()
+        plain_input = _make_plain_node('Read1')
+
+        stamped = self._run_copy_and_collect_stamps(anchor, plain_input)
+
+        self.assertNotIn(anchor, stamped,
+                         "Hidden-input anchor must not be stamped as a Local/Link dot")
+        self.assertNotIn(KNOB_NAME, anchor.knobs())
+        self.assertNotIn(DOT_TYPE_KNOB_NAME, anchor.knobs())
+
+    def test_scenario_d_anchor_with_dot_input_is_not_stamped(self):
+        """Scenario D: anchor (hidden input) + a Dot input → anchor unstamped."""
+        anchor = _make_hidden_input_anchor()
+        dot_input = _make_plain_node('Dot1', node_class='Dot')
+
+        stamped = self._run_copy_and_collect_stamps(anchor, dot_input)
+
+        self.assertNotIn(anchor, stamped,
+                         "Hidden-input anchor must not be stamped as a Local Dot")
+        self.assertNotIn(KNOB_NAME, anchor.knobs())
+        self.assertNotIn(DOT_TYPE_KNOB_NAME, anchor.knobs())
+
+    def test_scenario_b_anchor_with_link_is_not_stamped(self):
+        """Scenario B: anchor (hidden input) + a Link → anchor unstamped, link handled."""
+        anchor = _make_hidden_input_anchor()
+        link = _make_link_node('NoOp1')  # input is None → _stamp_for_link sets KNOB_NAME=""
+
+        stamped = self._run_copy_and_collect_stamps(anchor, link)
+
+        self.assertNotIn(anchor, stamped,
+                         "Anchor must not be stamped when copied alongside a Link")
+        self.assertNotIn(KNOB_NAME, anchor.knobs())
+
+
+# ---------------------------------------------------------------------------
+# Paste defensive guard — anchors never enter the hidden-input reconnect path
+# ---------------------------------------------------------------------------
+
+class TestPasteAnchorDefensiveGuard(unittest.TestCase):
+    """A pasted anchor carrying stale link knobs must remain an anchor."""
+
+    def test_stale_local_stamped_anchor_is_left_as_anchor(self):
+        """A pasted anchor with KNOB_NAME + DOT_TYPE='local' (as a pre-fix
+        clipboard could produce) must NOT be reconnected as a Local dot."""
+        stale_anchor = StubNode(
+            name=ANCHOR_PREFIX + 'Foo',
+            node_class='NoOp',
+            knobs_dict={
+                KNOB_NAME: _make_knob('sourceScript.Read1', knob_name=KNOB_NAME),
+                DOT_TYPE_KNOB_NAME: _make_knob('local', knob_name=DOT_TYPE_KNOB_NAME),
+                'label': _make_knob(''),
+                'tile_color': _make_knob(0),
+                'hide_input': _make_knob(True),
+                'selected': _make_knob(False),
+            },
+        )
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.is_anchor', side_effect=lambda n: n.name().startswith(ANCHOR_PREFIX)), \
+             patch('anchors.setup_link_node') as mock_setup_link_node, \
+             patch('anchors._find_local_node') as mock_find_local_node:
+
+            mock_nuke.nodePaste.return_value = None
+            mock_nuke.selectedNodes.return_value = [stale_anchor]
+
+            from anchors import paste_anchors
+            paste_anchors()
+
+        # The anchor must NOT have been routed into _handle_pasted_hidden_input().
+        mock_setup_link_node.assert_not_called()
+        mock_find_local_node.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Scenario A lock-in — copy-only-anchors still pastes as Links (Issue #37)
+# ---------------------------------------------------------------------------
+
+class TestScenarioAStillPastesAsLink(unittest.TestCase):
+    """Issue #55 confirms Scenario A is desired, not a misfeature: an all-anchor
+    selection must still be stamped DOT_TYPE='link' so it pastes as a Link —
+    even when the anchor's input wire is hidden."""
+
+    def test_all_anchor_selection_with_hidden_input_is_stamped_as_link(self):
+        anchor = _make_hidden_input_anchor('Anchor_Solo')
+
+        captured = {}
+
+        def fake_add_input_knob(node, dot_type=None):
+            node._knobs[KNOB_NAME] = StubKnob(knob_name=KNOB_NAME)
+            if dot_type is not None:
+                node._knobs[DOT_TYPE_KNOB_NAME] = StubKnob(dot_type, knob_name=DOT_TYPE_KNOB_NAME)
+            captured['dot_type'] = dot_type
+
+        with patch('anchors.nuke') as mock_nuke, \
+             patch('anchors.nukescripts'), \
+             patch('anchors.prefs') as mock_prefs, \
+             patch('anchors.is_link', return_value=False), \
+             patch('anchors.is_anchor', return_value=True), \
+             patch('anchors.add_input_knob', side_effect=fake_add_input_knob), \
+             patch('anchors.get_fully_qualified_node_name', side_effect=lambda n: n.name()):
+
+            _patch_copy(mock_nuke, [anchor], mock_prefs)
+
+            from anchors import copy_anchors
+            copy_anchors()
+
+        self.assertEqual(captured.get('dot_type'), 'link',
+                         "All-anchor selection must still be stamped for paste-as-link (Issue #37)")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #55.

## Problem

Copy-pasting an Anchor behaved inconsistently across the four scenarios in #55:

- **A** — copy an Anchor alone → pastes as a Link. *(Intentional — #37. Desired, kept.)*
- **B** — copy an Anchor + a Link → both paste correctly. *(Already worked.)*
- **C** — copy an Anchor + its input → the Anchor pasted as a Link pointing at the input. **(BUG)**
- **D** — copy an Anchor whose input is a Dot → the Anchor pasted as a Local Dot. **(BUG)**

## Root cause (C & D)

A dispatch-precedence bug. Anchors are built from `NoOp`/`Dot`, both in `HIDDEN_INPUT_CLASSES`. Both the copy and paste loops checked the hidden-input-dot branch **before** `is_anchor()`, so an anchor whose input wire was hidden (routine after Alt+H, or for Dot anchors) was misrouted into the hidden-dot path and stamped/reconnected as a Local/Link dot — keeping its anchor name/knobs but wired and styled as a dot.

## Fix

Make `is_anchor()` the higher-priority classification in both loops:

- `copy_anchors()` — check `is_anchor` before the hidden-input-dot branch. A hidden-input anchor in a mixed selection now reaches `_stamp_for_anchor` (which stamps nothing) instead of `_stamp_for_hidden_dot`.
- `paste_anchors()` — add `and not is_anchor(node)` to the hidden-input branch as a defensive, symmetric guard (covers stale clipboards from older versions).

**Scenario A is deliberately preserved** (copy-only-anchors → paste-as-Links, #37) and locked in by a regression test — it is desired behaviour, not a misfeature.

## Tests

- New `tests/test_issue55_anchor_paste.py`: scenarios C, D, B, the paste defensive guard, and the Scenario A lock-in. Verified they fail against the pre-fix precedence (4/5 fail when reverted).
- Tightened two `test_dot_type_distinction.py` tests that mocked `is_anchor` `True` for *all* nodes (including the Dot being copied) — now `True` only for the anchor input, matching real `is_anchor` for a non-anchor Dot.
- Full suite: **479 passed**.

## Manual UAT

Run in Nuke: A → Link, B → Anchor+Link, C → Anchor, D → Anchor; plus regression check that a plain hidden Dot still becomes a Local Dot (#56 behaviour intact).