### PR TITLE
fix: gate anchor shortcuts to DAG context (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ For Dot anchors, applying or appending a label also propagates the change to all
 | `Shift+B` | Label (Small) |
 | `Ctrl+M` | Append Label |
 
+All anchor shortcuts are scoped to the **DAG (Node Graph) context** — they only fire when the Node Graph has focus. This keeps them from intercepting keys (e.g. `Ctrl+C/X/V`) while you're typing in the Script Editor, Viewer, or other panels.
+
 # Preferences
 
 `Edit > Anchors > Anchor Preferences...` opens a dialog with:

--- a/constants.py
+++ b/constants.py
@@ -34,6 +34,14 @@ ANCHOR_DEFAULT_COLOR = 0x6f3399ff
 # darkened burnt orange: R=122,G=58,B=0 (~30% darker than previous 0xB35A00FF)
 LOCAL_DOT_COLOR = 0x7A3A00FF
 
+# === Keyboard shortcut context. ===
+# Nuke's menu.addCommand() accepts a shortcutContext that scopes where a
+# keyboard shortcut fires: 0 = window, 1 = application, 2 = DAG (Node Graph).
+# Anchor functions are only meaningful in the Node Graph, so binding their
+# shortcuts to the DAG context stops them from intercepting keys in the Script
+# Editor, Viewer, or other panels (issue #54).
+DAG_SHORTCUT_CONTEXT = 2
+
 # === Font sizes and colours. ===
 DOT_LABEL_FONT_SIZE_LARGE = 111
 DOT_LABEL_FONT_SIZE_MEDIUM = 66

--- a/menu.py
+++ b/menu.py
@@ -1,19 +1,24 @@
 import nuke
 
 import anchor
-import labels
 import anchors
+import labels
 import prefs
+from constants import DAG_SHORTCUT_CONTEXT
 
 menu = nuke.menu("Nuke")
 edit_menu = menu.findItem("Edit")
 
-menu.addCommand("Edit/Copy",  "anchors.copy_anchors()",  "^C")
-menu.addCommand("Edit/Cut",   "anchors.cut_anchors()",   "^X")
-menu.addCommand("Edit/Paste", "anchors.paste_anchors()", "^V")
+# Anchor shortcuts are gated to the DAG context so they only fire when the Node
+# Graph has focus — this avoids colliding with Script Editor / Viewer keys and
+# the confusion that caused (issue #54).
+menu.addCommand("Edit/Copy",  "anchors.copy_anchors()",  "^C", shortcutContext=DAG_SHORTCUT_CONTEXT)
+menu.addCommand("Edit/Cut",   "anchors.cut_anchors()",   "^X", shortcutContext=DAG_SHORTCUT_CONTEXT)
+menu.addCommand("Edit/Paste", "anchors.paste_anchors()", "^V", shortcutContext=DAG_SHORTCUT_CONTEXT)
 # Wrap the built-in Input On/Off so hiding a wired Dot's input stamps it into a
 # Local/Link dot in place (issue #56 — replaces the old copy-time side effect).
-menu.addCommand("Edit/Node/Input On/Off", "anchors.toggle_input_visibility()", "alt+h")
+menu.addCommand("Edit/Node/Input On/Off", "anchors.toggle_input_visibility()", "alt+h",
+                shortcutContext=DAG_SHORTCUT_CONTEXT)
 
 def _find_item_index(parent_menu, item_name):
     for position, menu_item in enumerate(parent_menu.items()):
@@ -38,10 +43,18 @@ _gated_menu_items = []
 
 
 def _add_gated_command(menu, name, command, shortcut=None, shortcut_context=None):
-    """Register a menu command and track its item reference for enable/disable."""
+    """Register a menu command and track its item reference for enable/disable.
+
+    Any command that binds a shortcut is gated to the DAG context by default
+    (issue #54) so anchor keys only fire when the Node Graph has focus and never
+    intercept keys in the Script Editor, Viewer, or other panels. Pass an
+    explicit shortcut_context to override.
+    """
     kwargs = {}
     if shortcut is not None:
         kwargs['shortcut'] = shortcut
+        if shortcut_context is None:
+            shortcut_context = DAG_SHORTCUT_CONTEXT
     if shortcut_context is not None:
         kwargs['shortcutContext'] = shortcut_context
     item = menu.addCommand(name, command, **kwargs)
@@ -55,7 +68,7 @@ _add_gated_command(anchors_menu, "Create Link",                "anchor.select_an
 _add_gated_command(anchors_menu, "Clear Link State",    "anchors.clear_link_state()")
 _add_gated_command(anchors_menu, "Anchor",              "anchor.anchor_shortcut()",            "A")
 _add_gated_command(anchors_menu, "Leader Key",          "import leader; leader.arm()",         "+A",
-                   shortcut_context=2)
+                   shortcut_context=DAG_SHORTCUT_CONTEXT)
 _add_gated_command(anchors_menu, "Reconnect All Links", "anchor.reconnect_all_links()")
 _add_gated_command(anchors_menu, "Anchor Find", "anchor.select_anchor_and_navigate()", "alt+A")
 _add_gated_command(anchors_menu, "Anchor Jump", "anchor.jump_to_selected_anchor()", "alt+J")
@@ -78,7 +91,8 @@ anchors_menu.addSeparator()
 # ---------------------------------------------------------------------------
 anchors_menu.addCommand("Copy (old)",  "anchors.copy_old()")
 anchors_menu.addCommand("Cut (old)",   "anchors.cut_old()")
-anchors_menu.addCommand("Paste (old)", "anchors.paste_old()", "+^D")
+anchors_menu.addCommand("Paste (old)", "anchors.paste_old()", "+^D",
+                        shortcutContext=DAG_SHORTCUT_CONTEXT)
 
 anchors_menu.addSeparator()
 anchors_menu.addCommand(

--- a/tests/test_menu_shortcut_context.py
+++ b/tests/test_menu_shortcut_context.py
@@ -1,0 +1,113 @@
+"""Tests for menu.py — anchor shortcuts gated to the DAG context (issue #54).
+
+Anchor functions are only meaningful in the Node Graph. Every menu command that
+binds a keyboard shortcut must register it with shortcutContext=2 (DAG context)
+so the key never fires while the Script Editor, Viewer, or another panel has
+focus. These tests import menu.py against a recording nuke stub and assert that
+every shortcut-bearing command carries the DAG context, while commands without a
+shortcut do not get a spurious context.
+"""
+
+import importlib
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+from constants import DAG_SHORTCUT_CONTEXT
+
+
+class _RecordingMenu:
+    """A nuke menu stand-in that records every addCommand call.
+
+    All recorded commands across every menu/submenu created during a menu.py
+    import are appended to the shared ``commands`` list so a single import can be
+    inspected as a whole.
+    """
+
+    def __init__(self, commands):
+        self._commands = commands
+
+    def addCommand(self, name, command=None, shortcut=None, **kwargs):
+        self._commands.append({
+            'name': name,
+            'command': command,
+            'shortcut': shortcut,
+            'shortcutContext': kwargs.get('shortcutContext'),
+        })
+        # Return an item exposing setEnabled so set_anchors_menu_enabled works.
+        item = MagicMock()
+        item.setEnabled = MagicMock()
+        return item
+
+    def addMenu(self, name, **kwargs):
+        return _RecordingMenu(self._commands)
+
+    def findItem(self, name):
+        return _RecordingMenu(self._commands)
+
+    def addSeparator(self):
+        pass
+
+    def items(self):
+        return []
+
+
+def _import_menu_with_recording_nuke():
+    """Import a fresh menu.py against a recording nuke stub; return its commands."""
+    recorded_commands = []
+
+    # conftest already installed a nuke stub; augment it with menu recording.
+    nuke_stub = sys.modules['nuke']
+    nuke_stub.menu = MagicMock(return_value=_RecordingMenu(recorded_commands))
+    nuke_stub.addOnScriptLoad = MagicMock()
+
+    sys.modules.pop('menu', None)
+    importlib.import_module('menu')
+    return recorded_commands
+
+
+class TestMenuShortcutContext(unittest.TestCase):
+    def setUp(self):
+        self.commands = _import_menu_with_recording_nuke()
+        self.by_shortcut = {
+            command['shortcut']: command
+            for command in self.commands
+            if command['shortcut'] is not None
+        }
+
+    def test_every_shortcut_is_dag_gated(self):
+        """Every command that binds a shortcut fires only in the DAG context."""
+        shortcut_commands = [c for c in self.commands if c['shortcut'] is not None]
+        self.assertTrue(shortcut_commands, "expected menu.py to register shortcuts")
+        for command in shortcut_commands:
+            self.assertEqual(
+                command['shortcutContext'],
+                DAG_SHORTCUT_CONTEXT,
+                f"{command['name']} (shortcut {command['shortcut']!r}) is not gated "
+                f"to the DAG context",
+            )
+
+    def test_known_shortcuts_are_gated(self):
+        """Spot-check the headline anchor shortcuts are present and DAG-gated."""
+        for shortcut in ('^C', '^X', '^V', 'A', '+A', 'alt+A', 'alt+J',
+                         'alt+L', 'alt+Z', '+M', '+N', '+B', '^M', '+^D'):
+            self.assertIn(shortcut, self.by_shortcut,
+                          f"shortcut {shortcut!r} was not registered")
+            self.assertEqual(
+                self.by_shortcut[shortcut]['shortcutContext'],
+                DAG_SHORTCUT_CONTEXT,
+                f"shortcut {shortcut!r} is not DAG-gated",
+            )
+
+    def test_commands_without_shortcuts_have_no_context(self):
+        """Commands without a shortcut should not carry a spurious context."""
+        for command in self.commands:
+            if command['shortcut'] is None:
+                self.assertIsNone(
+                    command['shortcutContext'],
+                    f"{command['name']} has shortcutContext without a shortcut",
+                )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #54.

## Problem

Anchor keyboard shortcuts were registered application-wide, so they fired regardless of which panel had focus. The most disruptive cases:

- `Ctrl+C` / `Ctrl+X` / `Ctrl+V` are wrapped to copy/cut/paste hidden-input anchors, so they intercepted ordinary text editing in the Script Editor.
- Single-key bindings like `A` collided with shortcuts in the Viewer and other panels.

Anchor functions are only meaningful in the Node Graph, so these shortcuts have no business firing elsewhere.

## Fix

Bind every shortcut-bearing anchor command to Nuke's **DAG shortcut context** (`shortcutContext=2`) so the keys only fire when the Node Graph has focus.

- Add a named `DAG_SHORTCUT_CONTEXT` constant in `constants.py`.
- `_add_gated_command` now defaults any command that binds a shortcut to the DAG context (an explicit `shortcut_context` still overrides).
- Apply the context to the top-level `Copy`/`Cut`/`Paste`/`Input On/Off` overrides and the `Paste (old)` fallback, which call `addCommand` directly.
- Switch the existing `Leader Key` binding from the literal `2` to the named constant.

The leader key already used `shortcutContext=2`; this extends the same gating to the rest of the anchor shortcuts for consistency.

## Tests

Adds `tests/test_menu_shortcut_context.py`, which imports `menu.py` against a recording `nuke` stub and asserts:

- every command that binds a shortcut is DAG-gated,
- the headline shortcuts (`^C`, `^X`, `^V`, `A`, `+A`, `alt+A/J/L/Z`, `+M/N/B`, `^M`, `+^D`) are all present and gated,
- commands without a shortcut carry no spurious context.

Full suite: 482 passed. README updated to document the DAG-context scoping.