### PR TITLE
fix: add margin around modules when zooming (#61)

### DIFF
--- a/anchor.py
+++ b/anchor.py
@@ -31,6 +31,7 @@ from constants import (
     DOT_LABEL_FONT_SIZE_LARGE,
     DOT_LABEL_FONT_SIZE_MEDIUM,
     KNOB_NAME,
+    MODULE_ZOOM_MARGIN_FACTOR,
     NODE_LABEL_FONT_SIZE_LARGE,
 )
 from link import (
@@ -1039,6 +1040,13 @@ def navigate_to_anchor(anchor_node):
         node["selected"].setValue(True)
 
     nuke.zoomToFitSelected()
+
+    # zoomToFitSelected() frames the module edge-to-edge with no padding, which
+    # reads as too tight (issue #61). Nuke's API has no fit margin, so zoom out
+    # slightly from the fitted framing to leave a margin around the module.
+    fitted_scale = nuke.zoom()
+    fitted_center = nuke.center()
+    nuke.zoom(fitted_scale * MODULE_ZOOM_MARGIN_FACTOR, fitted_center)
 
     nukescripts.clear_selection_recursive()
     for node in saved_selection:

--- a/constants.py
+++ b/constants.py
@@ -34,6 +34,14 @@ ANCHOR_DEFAULT_COLOR = 0x6f3399ff
 # darkened burnt orange: R=122,G=58,B=0 (~30% darker than previous 0xB35A00FF)
 LOCAL_DOT_COLOR = 0x7A3A00FF
 
+# === Navigation framing. ===
+# After nuke.zoomToFitSelected() frames a module edge-to-edge, navigate_to_anchor
+# zooms out by this factor to leave a margin around the module (issue #61).
+# Nuke's zoomToFitSelected() has no padding parameter, so the margin is applied
+# as a post-fit zoom-out: 0.85 leaves ~7.5% of the viewport as margin per side,
+# which lands in the requested ~100-200px range on a typical DAG panel.
+MODULE_ZOOM_MARGIN_FACTOR = 0.85
+
 # === Keyboard shortcut context. ===
 # Nuke's menu.addCommand() accepts a shortcutContext that scopes where a
 # keyboard shortcut fires: 0 = window, 1 = application, 2 = DAG (Node Graph).

--- a/tests/test_anchor_navigation.py
+++ b/tests/test_anchor_navigation.py
@@ -500,10 +500,23 @@ class TestNavigateToAnchorZoom(unittest.TestCase):
         _ensure_qt_stubs_support_mock_attributes()
         importlib.reload(anchor)
         import nuke as nuke_stub
-        nuke_stub.zoomToFitSelected.reset_mock()
+        # reset_mock(side_effect=True) clears any side_effect leaked by a prior
+        # test; the margin tests below assign side_effects on these shared mocks.
+        nuke_stub.zoomToFitSelected.reset_mock(side_effect=True)
         nuke_stub.selectedNodes.reset_mock()
+        nuke_stub.zoom.reset_mock(side_effect=True)
+        nuke_stub.zoom.return_value = 1.0
+        nuke_stub.center.reset_mock(side_effect=True)
+        nuke_stub.center.return_value = [0.0, 0.0]
         import nukescripts
         nukescripts.clear_selection_recursive.reset_mock()
+
+    def tearDown(self):
+        """Restore shared zoom/fit mocks so side_effects don't leak to other classes."""
+        import nuke as nuke_stub
+        nuke_stub.zoom = MagicMock(return_value=1.0)
+        nuke_stub.center = MagicMock(return_value=[0.0, 0.0])
+        nuke_stub.zoomToFitSelected.reset_mock(side_effect=True)
 
     def _make_anchor_node(self, xpos=0, ypos=0):
         """Return a StubNode acting as an anchor with a 'selected' knob."""
@@ -602,6 +615,50 @@ class TestNavigateToAnchorZoom(unittest.TestCase):
             anchor.navigate_to_anchor(anchor_node)
 
         self.assertEqual(selected_at_zoom_time, [True])
+
+    def test_zooms_out_for_margin_after_fit(self):
+        """After fitting, zoom is re-applied at fitted_scale * margin factor (issue #61)."""
+        import nuke as nuke_stub
+        from constants import MODULE_ZOOM_MARGIN_FACTOR
+        anchor_node = self._make_anchor_node()
+
+        fitted_scale = 2.0
+        fitted_center = [100.0, 200.0]
+        nuke_stub.zoom = MagicMock(return_value=fitted_scale)
+        nuke_stub.center = MagicMock(return_value=fitted_center)
+
+        with patch('anchor.upstream_ignoring_hidden', return_value=set()):
+            anchor.navigate_to_anchor(anchor_node)
+
+        setter_calls = [c for c in nuke_stub.zoom.call_args_list if c.args]
+        self.assertEqual(len(setter_calls), 1,
+                         msg="navigate_to_anchor must re-apply zoom exactly once for the margin")
+        applied_scale, applied_center = setter_calls[0].args
+        self.assertAlmostEqual(applied_scale, fitted_scale * MODULE_ZOOM_MARGIN_FACTOR)
+        self.assertEqual(applied_center, fitted_center)
+
+    def test_margin_zoom_out_happens_after_fit(self):
+        """The margin zoom-out must run after zoomToFitSelected, not before."""
+        import nuke as nuke_stub
+        anchor_node = self._make_anchor_node()
+
+        call_order = []
+
+        def record_zoom(*args, **kwargs):
+            call_order.append('zoom')
+            return 1.0  # the fitted scale read back by navigate_to_anchor
+
+        nuke_stub.zoom = MagicMock(side_effect=record_zoom)
+        nuke_stub.center = MagicMock(return_value=[0.0, 0.0])
+        nuke_stub.zoomToFitSelected.side_effect = lambda: call_order.append('fit')
+
+        with patch('anchor.upstream_ignoring_hidden', return_value=set()):
+            anchor.navigate_to_anchor(anchor_node)
+
+        self.assertEqual(call_order[0], 'fit',
+                         msg="zoomToFitSelected must run before the margin zoom-out")
+        self.assertEqual(call_order[-1], 'zoom',
+                         msg="the margin zoom-out must be the final framing call")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #61.

## Problem
Navigating to a module (an anchor plus its upstream nodes) framed the nodes edge-to-edge with no breathing room. Backdrops, by contrast, look well-framed because the backdrop node is physically larger than its contents, leaving natural margin.

## Root cause
`navigate_to_anchor()` selects the module nodes and calls `nuke.zoomToFitSelected()`, which fits the selection's bounding box to fill the viewport with no padding. Nuke's API exposes no margin/padding parameter for that call.

## Fix
Apply the margin as a post-fit zoom-out. After `zoomToFitSelected()`, read the resulting scale and center and re-zoom by a factor:

```python
fitted_scale = nuke.zoom()
fitted_center = nuke.center()
nuke.zoom(fitted_scale * MODULE_ZOOM_MARGIN_FACTOR, fitted_center)
```

`MODULE_ZOOM_MARGIN_FACTOR = 0.85` (new constant in `constants.py`) leaves ~7.5% of the viewport as margin on each side — roughly 100–200px on a typical DAG panel, matching the issue request — and adapts to any panel size rather than hard-coding a pixel count.

### Alternatives considered
- **Fixed-pixel margin via Qt viewport query**: would honor "100–200px" literally, but requires locating the DAG `QWidget` reliably across Nuke versions/docked panels and is much harder to unit-test. The proportional factor lands in the requested range with far less fragility.

## Tests
- `test_zooms_out_for_margin_after_fit` — verifies a single re-zoom at `fitted_scale * MODULE_ZOOM_MARGIN_FACTOR` with the fitted center.
- `test_margin_zoom_out_happens_after_fit` — verifies ordering (fit first, margin zoom-out last).
- `setUp`/`tearDown` hardened to reset shared zoom mocks so the new `side_effect`s don't leak across test classes.

Full suite: 484 passed.

## UAT
Pending — to be performed in Nuke by the maintainer (navigate to a module via Alt+A / leader key; confirm visible margin; confirm back-navigation and link-cycling still work).