### PR TITLE
fix: fit backdrops on navigation instead of forcing 100% zoom

### DIFF
--- a/anchor.py
+++ b/anchor.py
@@ -998,15 +998,17 @@ def cycle_next_link():
 def navigate_to_backdrop(backdrop_node):
     """Zoom the DAG to fit *backdrop_node*.
 
-    Uses nuke.zoom() rather than nuke.zoomToFitSelected() so that the
-    currently focused DAG panel (which may be a Group's internal panel)
-    is targeted instead of always zooming the root DAG.
+    Selects the backdrop and uses nuke.zoomToFitSelected() so the zoom scale
+    adapts to the backdrop's size.  The previous implementation used
+    nuke.zoom(1.0, center), which always jumped to 100% zoom regardless of
+    backdrop size and so zoomed in too far on large backdrops.  Navigation is
+    dispatched after the picker closes (see _anchor_navigate_invoke), so the
+    focused DAG panel is the active one by the time this runs — matching how
+    navigate_to_anchor already relies on zoomToFitSelected.
     """
     nukescripts.clear_selection_recursive()
     backdrop_node['selected'].setValue(True)
-    center_x = backdrop_node.xpos() + backdrop_node.screenWidth() // 2
-    center_y = backdrop_node.ypos() + backdrop_node.screenHeight() // 2
-    nuke.zoom(1.0, [center_x, center_y])
+    nuke.zoomToFitSelected()
     nukescripts.clear_selection_recursive()
 
 

--- a/tests/test_anchor_navigation.py
+++ b/tests/test_anchor_navigation.py
@@ -318,16 +318,37 @@ class TestNavigateToBackdrop(unittest.TestCase):
         nukescripts.clear_selection_recursive.reset_mock()
 
     def test_navigate_to_backdrop_selects_and_zooms(self):
-        """navigate_to_backdrop() calls backdrop['selected'].setValue(True) and nuke.zoom()."""
+        """navigate_to_backdrop() selects the backdrop and fits it with zoomToFitSelected()."""
         selected_knob = MagicMock()
         stub_backdrop = MagicMock()
         stub_backdrop.__getitem__ = MagicMock(return_value=selected_knob)
 
+        import nuke as nuke_stub
+        nuke_stub.zoom.reset_mock()
+
         anchor.navigate_to_backdrop(stub_backdrop)
 
         selected_knob.setValue.assert_called_with(True)
+        nuke_stub.zoomToFitSelected.assert_called_once()
+
+    def test_navigate_to_backdrop_does_not_force_fixed_zoom(self):
+        """navigate_to_backdrop() must fit the backdrop, not jump to a fixed zoom scale.
+
+        The old implementation called nuke.zoom(1.0, center), which zoomed in too
+        far on large backdrops; the fit must come from zoomToFitSelected() instead.
+        """
+        selected_knob = MagicMock()
+        stub_backdrop = MagicMock()
+        stub_backdrop.__getitem__ = MagicMock(return_value=selected_knob)
+
         import nuke as nuke_stub
-        nuke_stub.zoom.assert_called()
+        nuke_stub.zoom.reset_mock()
+
+        anchor.navigate_to_backdrop(stub_backdrop)
+
+        zoom_setter_calls = [c for c in nuke_stub.zoom.call_args_list if c.args]
+        self.assertEqual(zoom_setter_calls, [],
+                         msg="navigate_to_backdrop must not set an absolute zoom scale")
 
     def test_navigate_to_backdrop_clears_selection_before_and_after(self):
         """navigate_to_backdrop() calls nukescripts.clear_selection_recursive at least twice."""


### PR DESCRIPTION
## Problem
Navigating to a backdrop with Alt+A zoomed in too far on large backdrops, while small ones looked fine — an inconsistent "sometimes" framing. Selecting the same backdrop and running `zoomToFitSelected()` in the Script Editor framed it correctly.

This is a pre-existing bug, independent of the #61 / #62 / #63 module-margin work.

## Root cause
`navigate_to_backdrop()` called `nuke.zoom(1.0, [center_x, center_y])`. The first argument is an **absolute zoom scale** (100% — one node-grid unit per screen pixel), not a fit. So it always jumped to 100% regardless of backdrop size:
- Large backdrop → 100% is far more zoomed-in than fit → too far in.
- Small backdrop (~viewport-sized at 100%) → happens to look right.

The center math was correct; only the hardcoded scale was wrong.

## Fix
Select the backdrop and call `nuke.zoomToFitSelected()`, so the scale adapts to the backdrop's size — the same thing that works from the Script Editor.

```python
nukescripts.clear_selection_recursive()
backdrop_node['selected'].setValue(True)
nuke.zoomToFitSelected()
nukescripts.clear_selection_recursive()
```

The old docstring justified avoiding `zoomToFitSelected()` to target a Group's internal DAG panel rather than the root DAG. That reasoning is obsolete: navigation is dispatched after the picker closes via `QtCore.QTimer.singleShot` (`_anchor_navigate_invoke`), so the focused panel is already active — the exact path `navigate_to_anchor()` already uses with `zoomToFitSelected()`.

## Tests
- Updated `test_navigate_to_backdrop_selects_and_zooms` to assert `zoomToFitSelected()` is called.
- Added `test_navigate_to_backdrop_does_not_force_fixed_zoom` — asserts no absolute zoom scale is set.

Full suite: 486 passed.

## UAT
Pending — to be performed in Nuke by the maintainer:
- Navigate to a **large** backdrop with Alt+A → confirm it now fits (no longer zoomed in too far).
- Navigate to a **small** backdrop → still framed sensibly.
- Confirm backdrops **inside a Group's** node graph also fit correctly (the panel-targeting case the old docstring worried about).