### PR TITLE
fix: open anchor picker popups with a blank text field

### DIFF
--- a/tabtabtab_anchors.py
+++ b/tabtabtab_anchors.py
@@ -705,11 +705,12 @@ class TabTabTabWidget(QtWidgets.QDialog):
         self.things_model.set_filter(text)
 
     def show(self):
-        """Select all the text in the input (which persists between
-        show()'s)
+        """Always open with a blank input field.
 
-        Allows typing over previously created text, and [tab][tab] to
-        create previously created node (instead of the most popular)
+        The input text persists between show()'s (create() stamps the
+        last-created node's name into it). We clear it on every show so the
+        anchor picker / navigate popups always present an empty field rather
+        than the previous text, per user preference.
         """
 
         # Show the widget and focus the input *before* doing any heavy work.
@@ -719,7 +720,7 @@ class TabTabTabWidget(QtWidgets.QDialog):
         # first character or two get lost (issue #3). Deferring via
         # singleShot(0) lets Qt drain pending input events into the now-
         # focused line-edit before the refresh blocks the GUI thread again.
-        self.input.selectAll()
+        self.input.clear()
         super(TabTabTabWidget, self).show()
         self.input.setFocus()
 


### PR DESCRIPTION
## Summary

The **A** and **Alt-A** anchor popups now always open with a blank text field instead of pre-filling the previously created/searched text.

Both shortcuts share the forked `TabTabTabWidget` in `tabtabtab_anchors.py`. Its `create()` method stamps the last-created node's name into the input field, and `show()` previously called `self.input.selectAll()` to preserve that text (so you could type over it or Tab-Tab to recreate it). `show()` now calls `self.input.clear()` so the picker and navigate popups always present an empty field.

## Scope

`tabtabtab_anchors.py` is a dedicated fork used only by the anchor pickers in `anchor.py`, so this affects exactly the **A** (`anchor_shortcut`) and **Alt-A** (`select_anchor_and_navigate`) popups — Nuke's own Tab menu is untouched.

## Trade-off

This retires the old "reopen and press Tab/Enter on the still-present previous text to recreate it" behaviour, since the field no longer carries text forward. Weight-based ranking (most-used item pre-selected) still works.

## Testing

- Full suite: 486 passed.
